### PR TITLE
fix: fix coverage

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -50,6 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: llvm-cov
     steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
       - uses: actions/download-artifact@v5
         with:
           name: coverage


### PR DESCRIPTION
Refs: DEV-872

Intended commit merge for squash:

```
fix: fix Codecov upload

Uploads to Codecov were failing because the upload task was not checking
out the repo, and our previous setup masked this problem.

Refs: DEV-872
Signed-off-by: Alex <alex.corcoles@veecle.io>
```