### PR TITLE
chore: remove reference to non-existing examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Refer to [the Developer Certificate of Origin GitHub app](https://probot.github.
 
 1. Make your changes following the code quality guidelines below.
    - `cargo test` at the workspace root will check everything necessary, you may want to check just the subsets you're working on for faster feedback.
-2. Commit with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format (see examples in code quality section below).
+2. Commit with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
 3. Push your branch to your fork and open a Pull Request.
 4. Address feedback from maintainers as needed.
 


### PR DESCRIPTION
The code quality section doesn't have any example regarding conventional commits. I don't think they are necessary to add with the link to the [conventionalcommits.org](https://www.conventionalcommits.org/en/v1.0.0/) website.

<!---

Thanks for creating a pull request!

## TODO

 - 🚧 Consider if this PR is release-notes-worthy, and update CHANGELOG.md if so.

 - 🚧 Added/updated relevant documentation in README, crate, module, function and/or other locations.

 - 🚧 New tests added and/or existing tests adapted.

 - 🚧 PR is limited to a single logical change.
   For example, if you add a feature, don't include fixes you made along the way

 - 🚧 At least the first commit has a clear title and a descriptive message containing reasoning for the change.
   This will be included in the final commit message after squashing and merging.

 - 🚧 PR title starts with an appropriate prefix as specified by [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification):

       chore: [your title]
       docs: [your title]
       feat: [your title]
       fix: [your title]
       refactor: [your title]
       test: [your title]

 - 🚧 PR description explains what it intends to achieve.

 - 🚧 Relevant issues are linked.

 - 🚧 For more complex PRs, PR description explains _how_ this was achieved.
   Did you consider different approaches, were there any trade-offs you made?
   More information about why you implemented your solution the way you did helps reviewers.

(Feel free to delete this comment once you've checked your PR against the requirements, for a draft PR it can be useful to uncomment and leave not-yet-completed steps in a TODO section so reviewers know the current state).

-->
