### PR TITLE
chore: add workflow to deploy release archive to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,43 @@
+# Shorten the path in the GitHub UI.
+name: pages.yaml
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: The release to deploy
+        required: true
+        type: string
+
+# Based on the GitHub "Static HTML" workflow sample.
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/configure-pages@v5
+      - name: Download release archive
+        run: gh release --repo ${{ github.repository }} download ${{ inputs.release }} -p release-archive.zip
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Extract release archive
+        run: unzip release-archive.zip
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'release-archive'
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Requires:

* https://github.com/veecle/veecle-os/settings/pages
* Set the source to GitHub Actions.

I was able to run the workflow on the fork this PR comes from:

* https://github.com/alexveecle/veecle-os/actions/runs/17790271808
* https://alexveecle.github.io/veecle-os/

Refs: DEV-811