### PR TITLE
ci: skip workflows requiring secrets in PRs from forks

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     if: |
-      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+      ((github.event_name == 'pull_request' && !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '/claude-review') &&
-       github.event.comment.user.type != 'Bot')
+       github.event.comment.user.type != 'Bot'))
 
     permissions:
       contents: read

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -116,6 +116,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-private-docs
+    # Skip deployment if it's a PR from a fork (no access to secrets).
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       url: ${{ steps.wrangler.outputs.deployment-url }}
       alias-url: ${{ steps.wrangler.outputs.pages-deployment-alias-url }}
@@ -142,6 +144,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-user-manual
+    # Skip deployment if it's a PR from a fork (no access to secrets).
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       url: ${{ steps.wrangler.outputs.deployment-url }}
       alias-url: ${{ steps.wrangler.outputs.pages-deployment-alias-url }}
@@ -165,6 +169,8 @@ jobs:
   deploy-veecle-telemetry-ui-wasm:
     runs-on: ubuntu-latest
     needs: build-veecle-telemetry-ui-wasm
+    # Skip deployment if it's a PR from a fork (no access to secrets).
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       url: ${{ steps.wrangler.outputs.deployment-url }}
       alias-url: ${{ steps.wrangler.outputs.pages-deployment-alias-url }}
@@ -188,6 +194,8 @@ jobs:
   deploy-veecle-telemetry-ui-vscode:
     runs-on: ubuntu-latest
     needs: build-veecle-telemetry-ui-vscode
+    # Skip deployment if it's a PR from a fork (no access to secrets).
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       url: ${{ steps.wrangler.outputs.deployment-url }}
       alias-url: ${{ steps.wrangler.outputs.pages-deployment-alias-url }}
@@ -215,7 +223,8 @@ jobs:
       - deploy-private-docs
       - deploy-veecle-telemetry-ui-wasm
       - deploy-veecle-telemetry-ui-vscode
-    if: github.event_name == 'pull_request'
+    # Skip comment if it's a PR from a fork (deploy steps are skipped).
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     env:
       PR: ${{ github.event.number }}
       REF_NAME: ${{ github.ref_name }}


### PR DESCRIPTION
Fixes: DEV-887

Skips the actual deploy part of the deploy workflow as expected: https://github.com/veecle/veecle-os/pull/19

Claude fails with:
```
Failed to setup GitHub token: Error: Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch. If you're seeing this on a PR when you first add a code review workflow file to your repository, this is normal and you should ignore this error.

If you instead wish to use this action with a custom GitHub token or custom GitHub app, provide a `github_token` in the `uses` section of the app in your workflow yml file.
```

Which makes sense since the file is changed.

<!---

Thanks for creating a pull request!

## TODO

 - 🚧 Consider if this PR is release-notes-worthy, and update CHANGELOG.md if so.

 - 🚧 Added/updated relevant documentation in README, crate, module, function and/or other locations.

 - 🚧 New tests added and/or existing tests adapted.

 - 🚧 PR is limited to a single logical change.
   For example, if you add a feature, don't include fixes you made along the way

 - 🚧 At least the first commit has a clear title and a descriptive message containing reasoning for the change.
   This will be included in the final commit message after squashing and merging.

 - 🚧 PR title starts with an appropriate prefix as specified by [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification):

       chore: [your title]
       docs: [your title]
       feat: [your title]
       fix: [your title]
       refactor: [your title]
       test: [your title]

 - 🚧 PR description explains what it intends to achieve.

 - 🚧 Relevant issues are linked.

 - 🚧 For more complex PRs, PR description explains _how_ this was achieved.
   Did you consider different approaches, were there any trade-offs you made?
   More information about why you implemented your solution the way you did helps reviewers.

(Feel free to delete this comment once you've checked your PR against the requirements, for a draft PR it can be useful to uncomment and leave not-yet-completed steps in a TODO section so reviewers know the current state).

-->
