### PR TITLE
chore: remove `stdout` support from orchestrator

### DIFF
--- a/veecle-orchestrator-cli/src/lib.rs
+++ b/veecle-orchestrator-cli/src/lib.rs
@@ -59,12 +59,6 @@ enum Runtime {
     /// Stop the runtime instance with the passed id.
     Stop { id: InstanceId },
 
-    /// Show the output from the runtime instance with the passed id.
-    ///
-    /// Only gets output from now, but stays connected while the instance is stopped, so you can run `stdout` in one
-    /// terminal then `start` from another if you want output from the start.
-    Stdout { id: InstanceId },
-
     /// List known runtime instances.
     List,
 }
@@ -144,18 +138,6 @@ impl Arguments {
             Command::Runtime(Runtime::Stop { id }) => {
                 let () = send(&mut stream, Request::Stop(id))?;
                 println!("stopped instance {id}");
-            }
-            Command::Runtime(Runtime::Stdout { id }) => {
-                let () = send(&mut stream, Request::Stdout(id))?;
-
-                println!("connected to stdout for instance {id}");
-
-                let mut lines = stream.lines();
-                let mut stdout = std::io::stdout().lock();
-                while let Some(line) = lines.next().transpose().context("receiving stdout line")? {
-                    stdout.write_all(line.as_bytes())?;
-                    stdout.write_all(b"\n")?;
-                }
             }
             Command::Runtime(Runtime::List) => {
                 let info: Info = send(&mut stream, Request::Info)?;

--- a/veecle-orchestrator-protocol/src/lib.rs
+++ b/veecle-orchestrator-protocol/src/lib.rs
@@ -88,13 +88,6 @@ pub enum Request {
     /// Responds with <code>[Response]<()></code>.
     Stop(InstanceId),
 
-    /// Return stdout from the instance with the passed id.
-    ///
-    /// Responds with <code>[Response]<()></code>, then line-buffered lines from the instance's stdout until the
-    /// instance is removed.  When the instance is removed the connection will close, another `Request` cannot be sent
-    /// on the same connection.
-    Stdout(InstanceId),
-
     /// Link IPC for a data type identified by `type_name` to `to`.
     ///
     /// The same `type_name` can have multiple destinations, the data will be cloned to all.
@@ -153,7 +146,6 @@ impl Request {
             Self::Remove(_) => "Remove",
             Self::Start(_) => "Start",
             Self::Stop(_) => "Stop",
-            Self::Stdout(_) => "Stdout",
             Self::Link { .. } => "Link",
             Self::Info => "Info",
         }


### PR DESCRIPTION
This was leftover from before integrating `veecle-telemetry` and is currently broken (results in an infinite loop after the process quits).

We want all logs to go through the telemetry IPC channel, so rather than fixing just remove it.