### PR TITLE
fix: skip optional CI jobs when triggered by dependabot

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     if: |
-      ((github.event_name == 'pull_request' && !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository) ||
+      ((github.event_name == 'pull_request' && !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '/claude-review') &&

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -53,6 +53,8 @@ jobs:
   codecov-upload:
     runs-on: ubuntu-latest
     needs: llvm-cov
+    # Skip codecov upload for dependabot PRs (no access to secrets).
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -120,8 +120,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-private-docs
-    # Skip deployment if it's a PR from a fork (no access to secrets).
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # Skip deployment if it's a PR from a fork or dependabot (no access to secrets).
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     outputs:
       url: ${{ steps.wrangler.outputs.deployment-url }}
       alias-url: ${{ steps.wrangler.outputs.pages-deployment-alias-url }}
@@ -148,8 +148,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-user-manual
-    # Skip deployment if it's a PR from a fork (no access to secrets).
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # Skip deployment if it's a PR from a fork or dependabot (no access to secrets).
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     outputs:
       url: ${{ steps.wrangler.outputs.deployment-url }}
       alias-url: ${{ steps.wrangler.outputs.pages-deployment-alias-url }}
@@ -173,8 +173,8 @@ jobs:
   deploy-veecle-telemetry-ui-wasm:
     runs-on: ubuntu-latest
     needs: build-veecle-telemetry-ui-wasm
-    # Skip deployment if it's a PR from a fork (no access to secrets).
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # Skip deployment if it's a PR from a fork or dependabot (no access to secrets).
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     outputs:
       url: ${{ steps.wrangler.outputs.deployment-url }}
       alias-url: ${{ steps.wrangler.outputs.pages-deployment-alias-url }}
@@ -198,8 +198,8 @@ jobs:
   deploy-veecle-telemetry-ui-vscode:
     runs-on: ubuntu-latest
     needs: build-veecle-telemetry-ui-vscode
-    # Skip deployment if it's a PR from a fork (no access to secrets).
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # Skip deployment if it's a PR from a fork or dependabot (no access to secrets).
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     outputs:
       url: ${{ steps.wrangler.outputs.deployment-url }}
       alias-url: ${{ steps.wrangler.outputs.pages-deployment-alias-url }}
@@ -227,8 +227,8 @@ jobs:
       - deploy-private-docs
       - deploy-veecle-telemetry-ui-wasm
       - deploy-veecle-telemetry-ui-vscode
-    # Skip comment if it's a PR from a fork (deploy steps are skipped).
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    # Skip comment if it's a PR from a fork or dependabot (deploy steps are skipped).
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     env:
       PR: ${{ github.event.number }}
       REF_NAME: ${{ github.ref_name }}


### PR DESCRIPTION
`dependabot[bot]` doesn't have access to secrets even though it creates an "origin branch", so it needs to be specially excluded from jobs that excludes forks.

Also codecov doesn't allow the upload without a token because of something to do with branch protection.

Closes: DEV-903