### PR TITLE
ci: add `merge_group` trigger for CI runs

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -7,6 +7,7 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+  merge_group:
 
 # Cancel jobs for previous commits in the same branch.
 # On main `head_ref` is not available and `run_id` is always unique.

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,6 +7,7 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+  merge_group:
 
 # Cancel jobs for previous commits in the same branch.
 # On main `head_ref` is not available and `run_id` is always unique.

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -7,6 +7,7 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+  merge_group:
 
 # Cancel jobs for previous commits in the same branch.
 # On main `head_ref` is not available and `run_id` is always unique.


### PR DESCRIPTION
The trigger is required for the merge queue to be able to run those workflows.

Closes: DEV-957