### PR TITLE
ci: add a step to be able to require deployment builds to succeed

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -256,3 +256,16 @@ jobs:
           "
         env:
           GH_TOKEN: ${{ github.token }}
+
+  # Ensures all deployments are built. Used to require a single step to pass instead of multiple.
+  build-deployments:
+    runs-on: ubuntu-latest
+    needs:
+      - build-private-docs
+      - build-user-manual
+      - build-veecle-telemetry-ui-wasm
+      - build-veecle-telemetry-ui-vscode
+    if: always()
+    steps:
+      - run: exit 1
+        if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}


### PR DESCRIPTION
The `build-deployments` step will be added to the required checks to ensure deployments actually build. This will be used in merge-queues. See: https://github.com/veecle/veecle-os/pull/36