### PR TITLE
ci: validate commits in merge queue

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -42,7 +42,9 @@ jobs:
           convco: true
 
       - name: Check conventional commits
-        run: convco check "origin/${GITHUB_BASE_REF}.."
+        # We require squash-merge, which means only one commit will be added per PR.
+        # We cannot check the complete history as it contains a commit that doesn't follow conventional commits.
+        run: convco check -n 1
 
   validate-rust:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Moves the commit validation from PR to merge queue. This allows us to verify the commit that lands in `main` will actually have a correct commit message.

`GITHUB_BASE_REF` isn't available in merge queues/groups, so we just check the latest commit. Since we require squash-merge, this will be the only commit added per PR.