### PR TITLE
ci: more granular dependabot paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,9 @@ updates:
       interval: "weekly"
   - package-ecosystem: "cargo"
     directories:
-      - "**/*"
+      - "veecle-os-examples/*"
+      - "docs/user-manual/crates/*"
+      - "/"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
This unbreaks dependabot for our repo. It still doesn't do breaking bumps which is tracked in: https://github.com/dependabot/dependabot-core/issues/7896