### PR TITLE
chore: use full version number for all dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,8 +101,8 @@ poll-promise = { version = "0.3.0", default-features = false }
 pretty_assertions = { version = "1.4.1", default-features = false }
 prettyplease = { version = "0.2.37", default-features = false }
 proc-macro-crate = { version = "3.3.0", default-features = false }
-proc-macro2 = { version = "1.0", default-features = false }
-quote = { version = "1.0", default-features = false }
+proc-macro2 = { version = "1.0.95", default-features = false }
+quote = { version = "1.0.40", default-features = false }
 rand = { version = "0.9.2", default-features = false }
 re_log = { version = "0.24.1", default-features = false }
 rfd = { version = "0.15.4", default-features = false }
@@ -122,7 +122,7 @@ someip-test-service-sys = { path = "someip-test-service-sys", version = "0.1.0",
 someip-test-service-tests = { path = "someip-test-service-tests", version = "0.1.0", default-features = false }
 static_cell = { version = "2.1.1", default-features = false }
 strum = { version = "0.27.2", default-features = false }
-syn = { version = "2.0", default-features = false }
+syn = { version = "2.0.101", default-features = false }
 tempfile = { version = "3.22.0", default-features = false }
 test-case = { version = "3.3.1", default-features = false }
 thiserror = { version = "2.0.16", default-features = false }
@@ -167,7 +167,7 @@ veecle-telemetry-ui = { path = "veecle-telemetry-ui", version = "0.1.0", default
 wakerset = { version = "0.2.5", default-features = false }
 walkdir = { version = "2.5.0", default-features = false }
 wasm-bindgen = { version = "0.2.101", default-features = false }
-wasm-bindgen-futures = { version = "0.4", default-features = false }
+wasm-bindgen-futures = { version = "0.4.51", default-features = false }
 web-sys = { version = "0.3.78", default-features = false }
 web-time = { version = "1.1.0", default-features = false }
 

--- a/veecle-os-examples/freertos-stm32/Cargo.toml
+++ b/veecle-os-examples/freertos-stm32/Cargo.toml
@@ -18,8 +18,8 @@ cortex-m = { version = "0.7.7", default-features = false, features = [
   "critical-section-single-core",
 ] }
 cortex-m-rt = { version = "0.7.5", default-features = false }
-panic-halt = { version = "1.0", default-features = false }
-stm32f7xx-hal = { version = "0.8", default-features = false, features = [
+panic-halt = { version = "1.0.0", default-features = false }
+stm32f7xx-hal = { version = "0.8.0", default-features = false, features = [
   "rt",
   "stm32f767",
 ] }


### PR DESCRIPTION
For consistency. Uses the versions currently used in the Cargo.lock file.