### PR TITLE
ci: ignore heapless in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,7 @@ updates:
         dependency-type: "production"
       dev-dependencies:
         dependency-type: "development"
+    ignore:
+      # Embassy doesn't support heapless versions >=0.9.0.
+      - dependency-name: "heapless"
+        versions: [">=0.9.0"]


### PR DESCRIPTION
Embassy doesn't support `heapless` versions >=0.9.0.