### PR TITLE
fix: resolve veecle_telemetry crate path automatically in instrument macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+## Veecle OS
+
+* Fixed `veecle_os::telemetry::instrument` macro to automatically resolve correct crate paths for the facade.
+
 ## Veecle Telemetry VSCode Extension
 
 * **breaking** Removed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5147,6 +5147,7 @@ dependencies = [
 name = "veecle-telemetry-macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.106",

--- a/docs/user-manual/crates/getting-started/Cargo.lock
+++ b/docs/user-manual/crates/getting-started/Cargo.lock
@@ -842,6 +842,7 @@ dependencies = [
 name = "veecle-telemetry-macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",

--- a/docs/user-manual/crates/traces-serialization/Cargo.lock
+++ b/docs/user-manual/crates/traces-serialization/Cargo.lock
@@ -903,6 +903,7 @@ dependencies = [
 name = "veecle-telemetry-macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",

--- a/veecle-os-examples/common/Cargo.lock
+++ b/veecle-os-examples/common/Cargo.lock
@@ -459,6 +459,7 @@ dependencies = [
 name = "veecle-telemetry-macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",

--- a/veecle-os-examples/embassy-std/Cargo.lock
+++ b/veecle-os-examples/embassy-std/Cargo.lock
@@ -1093,6 +1093,7 @@ dependencies = [
 name = "veecle-telemetry-macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",

--- a/veecle-os-examples/freertos-linux/Cargo.lock
+++ b/veecle-os-examples/freertos-linux/Cargo.lock
@@ -1098,6 +1098,7 @@ dependencies = [
 name = "veecle-telemetry-macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",

--- a/veecle-os-examples/freertos-stm32/Cargo.lock
+++ b/veecle-os-examples/freertos-stm32/Cargo.lock
@@ -1012,6 +1012,7 @@ dependencies = [
 name = "veecle-telemetry-macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",

--- a/veecle-os-examples/orchestrator-ipc/Cargo.lock
+++ b/veecle-os-examples/orchestrator-ipc/Cargo.lock
@@ -849,6 +849,7 @@ dependencies = [
 name = "veecle-telemetry-macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",

--- a/veecle-os-examples/std/Cargo.lock
+++ b/veecle-os-examples/std/Cargo.lock
@@ -777,6 +777,7 @@ dependencies = [
 name = "veecle-telemetry-macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",

--- a/veecle-osal-std-macros/test-crates/veecle-os-crate/Cargo.lock
+++ b/veecle-osal-std-macros/test-crates/veecle-os-crate/Cargo.lock
@@ -758,6 +758,7 @@ dependencies = [
 name = "veecle-telemetry-macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",

--- a/veecle-telemetry-macros/Cargo.toml
+++ b/veecle-telemetry-macros/Cargo.toml
@@ -22,6 +22,7 @@ targets = []
 proc-macro = true
 
 [dependencies]
+proc-macro-crate = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = [

--- a/veecle-telemetry-macros/test-crates/README.md
+++ b/veecle-telemetry-macros/test-crates/README.md
@@ -1,0 +1,1 @@
+This folder contains test cases that require being independent crates, e.g. because they need very specific dependencies to test specific situations.

--- a/veecle-telemetry-macros/test-crates/renamed-veecle-telemetry-crate/Cargo.lock
+++ b/veecle-telemetry-macros/test-crates/renamed-veecle-telemetry-crate/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -18,14 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "auto-renamed-crate"
-version = "0.1.0"
-dependencies = [
- "veecle-osal-std",
- "veecle-telemetry",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,9 +25,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -43,14 +35,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bytes"
@@ -60,9 +52,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "darling"
@@ -207,20 +199,20 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "hex"
@@ -266,9 +258,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "lock_api"
@@ -282,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miniz_oxide"
@@ -308,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -443,18 +435,25 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
+name = "renamed-veecle-telemetry-crate"
+version = "0.1.0"
+dependencies = [
+ "veecle-telemetry",
+]
+
+[[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "ryu"
@@ -513,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -622,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "veecle-osal-api"
@@ -692,12 +691,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
@@ -783,24 +797,24 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/veecle-telemetry-macros/test-crates/renamed-veecle-telemetry-crate/Cargo.toml
+++ b/veecle-telemetry-macros/test-crates/renamed-veecle-telemetry-crate/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "renamed-veecle-telemetry-crate"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+publish = false
+
+[workspace]
+
+[dependencies]
+my-veecle-telemetry = { package = "veecle-telemetry", path = "../../../veecle-telemetry", features = [
+  "enable",
+  "std",
+] }

--- a/veecle-telemetry-macros/test-crates/renamed-veecle-telemetry-crate/src/lib.rs
+++ b/veecle-telemetry-macros/test-crates/renamed-veecle-telemetry-crate/src/lib.rs
@@ -1,0 +1,53 @@
+/// Test that the macro works when veecle-telemetry is renamed.
+
+// Synchronous functions:
+#[my_veecle_telemetry::instrument]
+pub fn sync_basic() {
+    unimplemented!("testing compilation")
+}
+
+#[my_veecle_telemetry::instrument(short_name = true)]
+pub fn sync_short_name() {
+    unimplemented!("testing compilation")
+}
+
+#[my_veecle_telemetry::instrument(name = "custom_name")]
+pub fn sync_custom_name() {
+    unimplemented!("testing compilation")
+}
+
+#[my_veecle_telemetry::instrument(properties = { "key": "value", "number": 42 })]
+pub fn sync_properties() {
+    unimplemented!("testing compilation")
+}
+
+#[my_veecle_telemetry::instrument(short_name = true, properties = { "param": "value" })]
+pub fn sync_short_name_and_properties() {
+    unimplemented!("testing compilation")
+}
+
+// Asynchronous functions:
+#[my_veecle_telemetry::instrument]
+pub async fn async_basic() {
+    unimplemented!("testing compilation")
+}
+
+#[my_veecle_telemetry::instrument(short_name = true)]
+pub async fn async_short_name() {
+    unimplemented!("testing compilation")
+}
+
+#[my_veecle_telemetry::instrument(name = "custom_async")]
+pub async fn async_custom_name() {
+    unimplemented!("testing compilation")
+}
+
+#[my_veecle_telemetry::instrument(properties = { "key": "value", "count": 10 })]
+pub async fn async_properties() {
+    unimplemented!("testing compilation")
+}
+
+#[my_veecle_telemetry::instrument(short_name = true, properties = { "id": 123 })]
+pub async fn async_short_name_and_properties() {
+    unimplemented!("testing compilation")
+}

--- a/veecle-telemetry-macros/test-crates/veecle-os-crate/Cargo.lock
+++ b/veecle-telemetry-macros/test-crates/veecle-os-crate/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -18,12 +18,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "auto-renamed-crate"
-version = "0.1.0"
-dependencies = [
- "veecle-osal-std",
- "veecle-telemetry",
-]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "autocfg"
@@ -33,9 +31,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -43,14 +41,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bytes"
@@ -60,9 +58,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "darling"
@@ -174,6 +172,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,10 +201,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "generic-array"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c8444bc9d71b935156cc0ccab7f622180808af7867b1daae6547d773591703"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -207,20 +226,26 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -266,9 +291,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "lock_api"
@@ -282,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miniz_oxide"
@@ -308,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -337,6 +362,12 @@ dependencies = [
  "smallvec",
  "windows-targets",
 ]
+
+[[package]]
+name = "pin-cell"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1f4c4ebd3c5f82080164b7d9cc8e505cd9536fda8c750b779daceb4b7180a7b"
 
 [[package]]
 name = "pin-project"
@@ -443,18 +474,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "ryu"
@@ -513,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -621,10 +652,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.18"
+name = "typenum"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "veecle-os"
+version = "0.1.0"
+dependencies = [
+ "veecle-os-runtime",
+ "veecle-osal-api",
+ "veecle-osal-std",
+ "veecle-telemetry",
+]
+
+[[package]]
+name = "veecle-os-crate"
+version = "0.1.0"
+dependencies = [
+ "veecle-os",
+]
+
+[[package]]
+name = "veecle-os-runtime"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "generic-array",
+ "pin-cell",
+ "pin-project",
+ "typenum",
+ "veecle-os-runtime-macros",
+ "veecle-telemetry",
+ "wakerset",
+]
+
+[[package]]
+name = "veecle-os-runtime-macros"
+version = "0.1.0"
+dependencies = [
+ "darling",
+ "heck",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "veecle-osal-api"
@@ -685,6 +765,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wakerset"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f434542e8bd0e49c3510ed64ac744e81e542d709a2385aa785fdb317ed284a48"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,12 +781,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
@@ -783,24 +887,24 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/veecle-telemetry-macros/test-crates/veecle-os-crate/Cargo.toml
+++ b/veecle-telemetry-macros/test-crates/veecle-os-crate/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "veecle-os-crate"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+publish = false
+
+[workspace]
+
+[dependencies]
+veecle-os = { path = "../../../veecle-os", features = [
+  "osal-std",
+  "telemetry-enable",
+] }

--- a/veecle-telemetry-macros/test-crates/veecle-os-crate/src/lib.rs
+++ b/veecle-telemetry-macros/test-crates/veecle-os-crate/src/lib.rs
@@ -1,0 +1,53 @@
+/// Test that telemetry macros can be used while depending only on `veecle-os`.
+
+// Synchronous functions:
+#[veecle_os::telemetry::instrument]
+pub fn sync_basic() {
+    unimplemented!("testing compilation")
+}
+
+#[veecle_os::telemetry::instrument(short_name = true)]
+pub fn sync_short_name() {
+    unimplemented!("testing compilation")
+}
+
+#[veecle_os::telemetry::instrument(name = "custom_name")]
+pub fn sync_custom_name() {
+    unimplemented!("testing compilation")
+}
+
+#[veecle_os::telemetry::instrument(properties = { "key": "value", "number": 42 })]
+pub fn sync_properties() {
+    unimplemented!("testing compilation")
+}
+
+#[veecle_os::telemetry::instrument(short_name = true, properties = { "param": "value" })]
+pub fn sync_short_name_and_properties() {
+    unimplemented!("testing compilation")
+}
+
+// Asynchronous functions:
+#[veecle_os::telemetry::instrument]
+pub async fn async_basic() {
+    unimplemented!("testing compilation")
+}
+
+#[veecle_os::telemetry::instrument(short_name = true)]
+pub async fn async_short_name() {
+    unimplemented!("testing compilation")
+}
+
+#[veecle_os::telemetry::instrument(name = "custom_async")]
+pub async fn async_custom_name() {
+    unimplemented!("testing compilation")
+}
+
+#[veecle_os::telemetry::instrument(properties = { "key": "value", "count": 10 })]
+pub async fn async_properties() {
+    unimplemented!("testing compilation")
+}
+
+#[veecle_os::telemetry::instrument(short_name = true, properties = { "id": 123 })]
+pub async fn async_short_name_and_properties() {
+    unimplemented!("testing compilation")
+}


### PR DESCRIPTION
The instrument macro was hardcoding `veecle_telemetry::` references in generated code, causing compilation failures when users only depended on `veecle-os` with the telemetry feature enabled.

Implemented automatic crate path resolution following the same pattern as `veecle-os-runtime-macros`:

- Added `proc-macro-crate` dependency
- Added `veecle_telemetry_path()` helper that tries `veecle-telemetry` first, then falls back to `veecle-os::telemetry`
- Updated all code generation functions to use the resolved path
- Added optional `crate` parameter for manual override

Added comprehensive test crates at `veecle-telemetry-macros/test-crates/`:

- `veecle-os-crate`: Tests `#[veecle_os::telemetry::instrument]` usage
- `renamed-veecle-telemetry-crate`: Tests renamed dependency scenario

Both test all parameter combinations (sync/async, basic, short_name, custom name, properties, and combinations).

Closes: DEV-998