### PR TITLE
feat: add deserialization to can frame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4898,7 +4898,7 @@ dependencies = [
  "camino",
  "serde",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -4976,6 +4976,7 @@ dependencies = [
  "libtest-mimic",
  "pretty_assertions",
  "serde",
+ "serde_json",
  "syn 2.0.106",
  "test-case",
  "tinyvec",

--- a/veecle-os-data-support-can/Cargo.toml
+++ b/veecle-os-data-support-can/Cargo.toml
@@ -33,6 +33,7 @@ veecle-os-runtime = { workspace = true }
 hex = { workspace = true, features = ["alloc"] }
 libtest-mimic = { workspace = true }
 pretty_assertions = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
 syn = { workspace = true, features = ["parsing"] }
 test-case = { workspace = true }
 veecle-os-data-support-can-codegen = { workspace = true }

--- a/veecle-os-data-support-can/src/id.rs
+++ b/veecle-os-data-support-can/src/id.rs
@@ -129,7 +129,7 @@ impl From<ExtendedId> for Id {
 
 /// All `Id` values are <0x2000_0000 so we have the top three bits spare, this type packs the discriminant into the top
 /// bit and removes alignment to minimize the storage space required.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
 #[repr(Rust, packed)]
 pub struct PackedId(u32);
 
@@ -182,5 +182,13 @@ mod tests {
             assert_eq!(extended_id.to_raw(), u32::from(extended_id));
             assert_eq!(id, extended_id.to_raw());
         }
+    }
+
+    #[test]
+    fn test_deserialize_packed_id() {
+        let id = PackedId::from(Id::from(ExtendedId::new_unwrap(0x1234_5678)));
+        let serialized = serde_json::to_string(&id).unwrap();
+        let deserialized: PackedId = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(id, deserialized);
     }
 }


### PR DESCRIPTION
This allows the users of our library to implement their own serialization and deserialization to send and receive frames directly.