### PR TITLE
feat: add clear command to orchestrator

### DIFF
--- a/veecle-orchestrator-cli/src/lib.rs
+++ b/veecle-orchestrator-cli/src/lib.rs
@@ -36,6 +36,9 @@ enum Command {
 
     #[command(subcommand)]
     Link(Link),
+
+    /// Stop all active runtimes and clear all orchestrator state.
+    Clear,
 }
 
 /// Manage runtimes registered on the orchestrator.
@@ -224,6 +227,10 @@ impl Arguments {
                                 .map(|(ty, to)| { [ty.to_string(), to.iter().join("\n")] })
                         )
                 );
+            }
+            Command::Clear => {
+                let () = send(&mut stream, Request::Clear)?;
+                println!("cleared orchestrator state");
             }
         }
         Ok(())

--- a/veecle-orchestrator-protocol/src/lib.rs
+++ b/veecle-orchestrator-protocol/src/lib.rs
@@ -119,6 +119,11 @@ pub enum Request {
     ///
     /// Response with <code>[Response]<[Info]></code>
     Info,
+
+    /// Stop all active runtimes and clear all orchestrator state.
+    ///
+    /// Responds with <code>[Response]<()></code>.
+    Clear,
 }
 
 /// A local or remote instance for an IPC link target.
@@ -164,6 +169,7 @@ impl Request {
             Self::Stop(_) => "Stop",
             Self::Link { .. } => "Link",
             Self::Info => "Info",
+            Self::Clear => "Clear",
         }
     }
 

--- a/veecle-orchestrator/src/api.rs
+++ b/veecle-orchestrator/src/api.rs
@@ -181,6 +181,11 @@ async fn handle_request(
             runtimes: conductor.info(),
             links: distributor.info().await?,
         })?,
+        Request::Clear => {
+            conductor.clear().await;
+            distributor.clear().await.wrap_err("clearing distributor")?;
+            encode(())?
+        }
     };
 
     Ok((response, None))

--- a/veecle-os-examples/orchestrator-ipc/run.sh
+++ b/veecle-os-examples/orchestrator-ipc/run.sh
@@ -98,6 +98,8 @@ echo
 echo 'Starting veecle-telemetry-server and orchestrators'
 echo
 
+export VEECLE_ORCHESTRATOR_LOG=debug
+
 run-background "$UI_SERVER" --bind "$EXAMPLE_IP" --port "$UI_WEBSOCKET_PORT" --telemetry-socket "$TELEMETRY_SOCKET"
 run-background "$ORCHESTRATOR" --control-socket "$CONTROL1" --ipc-socket $IPC1 --telemetry-socket "$TELEMETRY_SOCKET"
 run-background "$ORCHESTRATOR" --control-socket "$CONTROL2" --ipc-socket $IPC2 --telemetry-socket "$TELEMETRY_SOCKET"
@@ -123,6 +125,18 @@ run "$CLI" --socket "$CONTROL1" link add --type $mod::Pong --to $PING_ID
 
 run "$CLI" --socket "$CONTROL1" runtime list
 run "$CLI" --socket "$CONTROL1" link list
+
+run "$CLI" --socket "$CONTROL2" runtime list
+run "$CLI" --socket "$CONTROL2" link list
+
+run "$CLI" --socket "$CONTROL2" clear
+
+run "$CLI" --socket "$CONTROL2" runtime list
+run "$CLI" --socket "$CONTROL2" link list
+
+run "$CLI" --socket "$CONTROL2" runtime add "$PONG" --id $PONG_ID --copy
+run "$CLI" --socket "$CONTROL2" link add --type $mod::Ping --to $PONG_ID
+run "$CLI" --socket "$CONTROL2" link add --type $mod::Pong --to $IPC1
 
 run "$CLI" --socket "$CONTROL2" runtime list
 run "$CLI" --socket "$CONTROL2" link list


### PR DESCRIPTION
Add a `clear` command that stops all active runtimes and clears all orchestrator state. This allows resetting the orchestrator without restarting the process.

Also improve socket cleanup by using `NamedTempFile<AsyncUnixListener>` owned by IPC tasks. `RuntimeInstance`'s Drop implementation now aborts IPC tasks, ensuring sockets are cleaned up when instances are removed or cleared.

Closes: DEV-1035