### PR TITLE
chore: block dependabot `embedded-async-io` update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,6 @@ updates:
       # Embassy doesn't support heapless versions >=0.9.0.
       - dependency-name: "heapless"
         versions: [">=0.9.0"]
+      # DEV-1037, updating requires API breaking changes.
+      - dependency-name: "embedded-io-async"
+        versions: [">=0.7.0"]


### PR DESCRIPTION
Requires an explicit update as it involves breaking the public API.

Refs: DEV-1037