### PR TITLE
feat: implement manual `Serialize`/`Deserialize` for CAN id types

### DIFF
--- a/veecle-os-data-support-can/src/frame.rs
+++ b/veecle-os-data-support-can/src/frame.rs
@@ -96,14 +96,21 @@ mod tests {
     use crate::Frame;
 
     #[test]
-    fn test_deserialize_frame() {
-        let json = r#"{
-            "id": 0,
-            "data": [1, 2, 3, 4]
-        }"#;
+    fn test_deserialize_frame_standard() {
+        let json = r#"{"id":{"Standard":291},"data":[1,2,3,4]}"#;
         let frame: Frame = serde_json::from_str(json).unwrap();
-        assert_eq!(frame.id(), crate::StandardId::new(0).unwrap().into());
+        assert_eq!(frame.id(), crate::StandardId::new(0x123).unwrap().into());
         assert_eq!(frame.data(), &[1, 2, 3, 4]);
+        assert_eq!(json, serde_json::to_string(&frame).unwrap());
+    }
+
+    #[test]
+    fn test_deserialize_frame_extended() {
+        let json = r#"{"id":{"Extended":74565},"data":[1,2,3,4]}"#;
+        let frame: Frame = serde_json::from_str(json).unwrap();
+        assert_eq!(frame.id(), crate::ExtendedId::new(74565).unwrap().into());
+        assert_eq!(frame.data(), &[1, 2, 3, 4]);
+        assert_eq!(json, serde_json::to_string(&frame).unwrap());
     }
 
     /// More of an example of the output format than a real test, but as a test to force updating it.

--- a/veecle-os-data-support-can/src/id.rs
+++ b/veecle-os-data-support-can/src/id.rs
@@ -1,9 +1,9 @@
 /// A standard CAN id.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub struct StandardId(u16);
 
 /// An extended CAN id.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub struct ExtendedId(u32);
 
 impl StandardId {
@@ -59,6 +59,17 @@ impl core::fmt::Debug for StandardId {
     }
 }
 
+impl<'de> serde::Deserialize<'de> for StandardId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = u16::deserialize(deserializer)?;
+        StandardId::new(value)
+            .ok_or_else(|| serde::de::Error::custom("standard CAN id must be < 0x800"))
+    }
+}
+
 impl ExtendedId {
     /// Creates an `ExtendedId`, returns `Some` if, and only if, `value < 0x2000_0000`.
     pub const fn new(value: u32) -> Option<Self> {
@@ -105,8 +116,19 @@ impl core::fmt::Debug for ExtendedId {
     }
 }
 
+impl<'de> serde::Deserialize<'de> for ExtendedId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = u32::deserialize(deserializer)?;
+        ExtendedId::new(value)
+            .ok_or_else(|| serde::de::Error::custom("extended CAN id must be < 0x2000_0000"))
+    }
+}
+
 /// Either a standard or extended CAN id.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
 pub enum Id {
     /// A standard CAN id.
     Standard(StandardId),
@@ -129,7 +151,7 @@ impl From<ExtendedId> for Id {
 
 /// All `Id` values are <0x2000_0000 so we have the top three bits spare, this type packs the discriminant into the top
 /// bit and removes alignment to minimize the storage space required.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(Rust, packed)]
 pub struct PackedId(u32);
 
@@ -153,18 +175,47 @@ impl From<PackedId> for Id {
     }
 }
 
+// Manual serde implementations to serialize/deserialize via the `Id` enum instead of the packed representation.
+// This ensures the serialized format uses the logical representation and deserialization maintains invariants.
+impl serde::Serialize for PackedId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Id::from(*self).serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for PackedId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let id = Id::deserialize(deserializer)?;
+        Ok(PackedId::from(id))
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::format;
+    use std::string::ToString;
+
     use crate::id::PackedId;
     use crate::{ExtendedId, Id, StandardId};
 
+    const STANDARD_ID_VALIDS: [u16; 4] = [0, 1, 0x7FE, 0x7FF];
+    const STANDARD_ID_INVALIDS: [u16; 2] = [0x800, 0xFFFF];
+    const EXTENDED_ID_VALIDS: [u32; 4] = [0, 1, 0x1FFF_FFFE, 0x1FFF_FFFF];
+    const EXTENDED_ID_INVALIDS: [u32; 2] = [0x2000_0000, 0xFFFF_FFFF];
+
     #[test]
     fn pack_roundtrip() {
-        for id in [0, 1, 0x7FE, 0x7FF] {
+        for id in STANDARD_ID_VALIDS {
             let id = Id::Standard(StandardId::new(id).unwrap());
             assert_eq!(id, Id::from(PackedId::from(id)));
         }
-        for id in [0, 1, 0x1FFF_FFFE, 0x1FFF_FFFF] {
+        for id in EXTENDED_ID_VALIDS {
             let id = Id::Extended(ExtendedId::new(id).unwrap());
             assert_eq!(id, Id::from(PackedId::from(id)));
         }
@@ -172,23 +223,87 @@ mod tests {
 
     #[test]
     fn id_to_integer() {
-        for id in [0, 1, 0x7FE, 0x7FF] {
-            let standard_id = StandardId::new(id).unwrap();
+        for value in STANDARD_ID_VALIDS {
+            let standard_id = StandardId::new(value).unwrap();
             assert_eq!(standard_id.to_raw(), u16::from(standard_id));
-            assert_eq!(id, standard_id.to_raw());
+            assert_eq!(value, standard_id.to_raw());
         }
-        for id in [0, 1, 0x1FFF_FFFE, 0x1FFF_FFFF] {
-            let extended_id = ExtendedId::new(id).unwrap();
+        for value in EXTENDED_ID_VALIDS {
+            let extended_id = ExtendedId::new(value).unwrap();
             assert_eq!(extended_id.to_raw(), u32::from(extended_id));
-            assert_eq!(id, extended_id.to_raw());
+            assert_eq!(value, extended_id.to_raw());
         }
     }
 
     #[test]
-    fn test_deserialize_packed_id() {
-        let id = PackedId::from(Id::from(ExtendedId::new_unwrap(0x1234_5678)));
-        let serialized = serde_json::to_string(&id).unwrap();
-        let deserialized: PackedId = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(id, deserialized);
+    fn test_deserialize_standard_id_valid() {
+        for value in STANDARD_ID_VALIDS {
+            let json = value.to_string();
+            let id: StandardId = serde_json::from_str(&json).unwrap();
+            assert_eq!(id, StandardId::new(value).unwrap());
+            assert_eq!(json, serde_json::to_string(&id).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_deserialize_standard_id_invalid() {
+        for value in STANDARD_ID_INVALIDS {
+            let json = value.to_string();
+            assert!(serde_json::from_str::<StandardId>(&json).is_err());
+        }
+    }
+
+    #[test]
+    fn test_deserialize_extended_id_valid() {
+        for value in EXTENDED_ID_VALIDS {
+            let json = value.to_string();
+            let id: ExtendedId = serde_json::from_str(&json).unwrap();
+            assert_eq!(id, ExtendedId::new(value).unwrap());
+            assert_eq!(json, serde_json::to_string(&id).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_deserialize_extended_id_invalid() {
+        for value in EXTENDED_ID_INVALIDS {
+            let json = value.to_string();
+            assert!(serde_json::from_str::<ExtendedId>(&json).is_err());
+        }
+    }
+
+    #[test]
+    fn test_deserialize_id_and_packed_id_valid() {
+        for value in STANDARD_ID_VALIDS {
+            let json = format!(r#"{{"Standard":{value}}}"#);
+            let id: Id = serde_json::from_str(&json).unwrap();
+            assert_eq!(id, Id::Standard(StandardId::new(value).unwrap()));
+            assert_eq!(json, serde_json::to_string(&id).unwrap());
+            let packed: PackedId = serde_json::from_str(&json).unwrap();
+            assert_eq!(packed, PackedId::from(id));
+            assert_eq!(json, serde_json::to_string(&packed).unwrap());
+        }
+        for value in EXTENDED_ID_VALIDS {
+            let json = format!(r#"{{"Extended":{value}}}"#);
+            let id: Id = serde_json::from_str(&json).unwrap();
+            assert_eq!(id, Id::Extended(ExtendedId::new(value).unwrap()));
+            assert_eq!(json, serde_json::to_string(&id).unwrap());
+            let packed: PackedId = serde_json::from_str(&json).unwrap();
+            assert_eq!(packed, PackedId::from(id));
+            assert_eq!(json, serde_json::to_string(&packed).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_deserialize_id_and_packed_id_invalid() {
+        for value in STANDARD_ID_INVALIDS {
+            let json = format!(r#"{{"Standard":{value}}}"#);
+            assert!(serde_json::from_str::<Id>(&json).is_err());
+            assert!(serde_json::from_str::<PackedId>(&json).is_err());
+        }
+        for value in EXTENDED_ID_INVALIDS {
+            let json = format!(r#"{{"Extended":{value}}}"#);
+            assert!(serde_json::from_str::<Id>(&json).is_err());
+            assert!(serde_json::from_str::<PackedId>(&json).is_err());
+        }
     }
 }


### PR DESCRIPTION
Manual implementations for `PackedId`, `StandardId`, and `ExtendedId` to ensure proper validation and representation:

- `PackedId`: Delegates to `Id` enum to serialize/deserialize the logical representation instead of packed internal format
- `StandardId`: Validates values are < 0x800 during deserialization
- `ExtendedId`: Validates values are < 0x2000_0000 during deserialization

This ensures:
1. Serialized format uses logical `Id` representation, not packed bits
2. Deserialization validates all CAN id values are within valid ranges
3. Invariants are maintained for all id types

Closes: DEV-1006