### PR TITLE
ci: disable binary cache in `rust-cache`

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -36,6 +36,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
         with:
+          cache-bin: "false"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # `someip` tests `cargo run` this binary internally, pre-build it so they don't timeout.

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,6 +36,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
         with:
+          cache-bin: "false"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - run: just build-private-docs

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -65,6 +65,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
         with:
+          cache-bin: "false"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # `someip` tests `cargo run` this binary internally, pre-build it so they don't timeout.
@@ -107,6 +108,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
         with:
+          cache-bin: "false"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - run: cargo nextest run --package workspace -E 'test(/^veecle-os::(clippy|doc)$/)' --no-fail-fast
@@ -130,6 +132,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
         with:
+          cache-bin: "false"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - run: cargo nextest run --package workspace -E 'not test(/^veecle-os::/)' --no-fail-fast


### PR DESCRIPTION
The binaries are cached by the `setup-tools` action. Caching them again in the `rust-cache` action unnecessarily increases cache size.

We cannot move the binary cache to the `rust-cache` action because we want to cache each binary separately to enable fine-grained version updates.

Refs: DEV-1047