### PR TITLE
feat(osal): add thread id query mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * **breaking** Telemetry functionality is now always compiled into the runtime.
   The `veecle-telemetry` feature flag has been removed from `veecle-os-runtime`.
   Use the `telemetry-enable` feature flag on `veecle-os` to control telemetry behavior.
+* Added `ThreadAbstraction` trait to OSAL for querying current thread id.
 * Fixed `veecle_os::telemetry::instrument` macro to automatically resolve correct crate paths for the facade.
 
 ## Veecle Telemetry VSCode Extension

--- a/veecle-osal-api/src/lib.rs
+++ b/veecle-osal-api/src/lib.rs
@@ -9,6 +9,7 @@ extern crate std;
 mod error;
 pub mod log;
 pub mod net;
+pub mod thread;
 pub mod time;
 
 pub use error::{Error, Result};

--- a/veecle-osal-api/src/thread.rs
+++ b/veecle-osal-api/src/thread.rs
@@ -1,0 +1,23 @@
+//! Abstractions for thread-related operations.
+
+/// `ThreadAbstraction` is used to query thread-related information in a platform-agnostic manner.
+pub trait ThreadAbstraction {
+    /// Returns a unique identifier for the current thread.
+    ///
+    /// The returned id is guaranteed to be unique within the lifetime of the process.
+    /// Thread ids are not reused, even after a thread terminates.
+    ///
+    /// This is useful for telemetry and tracing, where thread ids can be included
+    /// in spans and logs to help correlate events to specific threads of execution.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use veecle_osal_api::thread::ThreadAbstraction;
+    /// use veecle_osal_std::thread::Thread;
+    ///
+    /// let thread_id = Thread::current_thread_id();
+    /// println!("Current thread id: {}", thread_id);
+    /// ```
+    fn current_thread_id() -> u64;
+}

--- a/veecle-osal-std/src/lib.rs
+++ b/veecle-osal-std/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod log;
 pub mod net;
+pub mod thread;
 pub mod time;
 
 pub use veecle_osal_api::{Error, Result};

--- a/veecle-osal-std/src/thread.rs
+++ b/veecle-osal-std/src/thread.rs
@@ -1,0 +1,81 @@
+//! Thread-related abstractions.
+
+use std::cell::Cell;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub use veecle_osal_api::thread::ThreadAbstraction;
+
+/// Implements the [`ThreadAbstraction`] trait for standard Rust.
+#[derive(Debug)]
+pub struct Thread;
+
+/// Global counter for generating unique thread ids.
+static NEXT_THREAD_ID: AtomicU64 = AtomicU64::new(1);
+
+thread_local! {
+    /// Thread-local storage for the current thread's id.
+    static THREAD_ID: Cell<u64> = const { Cell::new(0) };
+}
+
+impl ThreadAbstraction for Thread {
+    fn current_thread_id() -> u64 {
+        THREAD_ID.with(|id| {
+            let current = id.get();
+            if current == 0 {
+                // `Relaxed` here is enough because we don't care about what values various threads
+                // see, just that they're unique (assuming that creating 2^64 threads is impractical
+                // so overflow can't happen).
+                let new_id = NEXT_THREAD_ID.fetch_add(1, Ordering::Relaxed);
+                id.set(new_id);
+                new_id
+            } else {
+                current
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_thread_id_consistency() {
+        let id1 = Thread::current_thread_id();
+        let id2 = Thread::current_thread_id();
+        assert_eq!(
+            id1, id2,
+            "Thread id should be consistent within the same thread"
+        );
+    }
+
+    #[test]
+    fn test_thread_id_uniqueness() {
+        let main_id = Thread::current_thread_id();
+
+        let handle1 = std::thread::spawn(Thread::current_thread_id);
+        let handle2 = std::thread::spawn(Thread::current_thread_id);
+
+        let thread1_id = handle1.join().unwrap();
+        let thread2_id = handle2.join().unwrap();
+
+        assert_ne!(
+            main_id, thread1_id,
+            "Main thread and thread 1 should have different ids"
+        );
+        assert_ne!(
+            main_id, thread2_id,
+            "Main thread and thread 2 should have different ids"
+        );
+        assert_ne!(
+            thread1_id, thread2_id,
+            "Thread 1 and thread 2 should have different ids"
+        );
+    }
+
+    #[test]
+    fn test_thread_id_non_zero() {
+        let id = Thread::current_thread_id();
+        assert_ne!(id, 0, "Thread id should never be zero");
+    }
+}


### PR DESCRIPTION
Add `ThreadAbstraction` trait to query current thread id for use in telemetry spans and execution tracking.

`std` implementation uses thread-local storage initialized from a static atomic counter to ensure unique ids per thread without unsafe code.

Closes: DEV-912