### PR TITLE
chore: ignore coverage data for test code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,8 @@ Code coverage is checked using [`llvm-cov`](https://github.com/taiki-e/cargo-llv
 This can be run with `just coverage`.
 CI uses a nightly version of Rust to generate the coverage data.
 To achieve the same coverage output, set the default Rust toolchain for the repository root to the toolchain defined in the `rust-toolchain-nightly.toml` file.
+`llvm-cov` sets the `coverage_nightly` `cfg` value, which is used to conditionally enable the nightly `coverage_attribute` feature.
+Test modules should have `#[cfg_attr(coverage_nightly, coverage(off))]` set, to avoid coverage data being distorted by test code.
 
 ## Adding additional workspaces
 

--- a/veecle-ipc/src/lib.rs
+++ b/veecle-ipc/src/lib.rs
@@ -46,6 +46,7 @@
 //! ```
 
 #![forbid(unsafe_code)]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 #[cfg(doc)]
 extern crate self as veecle_ipc;

--- a/veecle-ipc/src/telemetry.rs
+++ b/veecle-ipc/src/telemetry.rs
@@ -29,6 +29,7 @@ impl Export for Exporter {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use tokio::sync::mpsc;
     use veecle_telemetry::collector::Export;

--- a/veecle-net-utils/src/address.rs
+++ b/veecle-net-utils/src/address.rs
@@ -263,6 +263,7 @@ impl TryFrom<MultiSocketAddress> for UnresolvedMultiSocketAddress {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::{
         UnresolvedMultiSocketAddress, UnresolvedSocketAddress, UnresolvedSocketAddressParseError,

--- a/veecle-net-utils/src/async_io.rs
+++ b/veecle-net-utils/src/async_io.rs
@@ -184,6 +184,7 @@ impl AsyncWrite for AsyncSocketStream {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::str::FromStr;
 

--- a/veecle-net-utils/src/blocking.rs
+++ b/veecle-net-utils/src/blocking.rs
@@ -60,6 +60,7 @@ impl Write for BlockingSocketStream {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::io::{Read, Write};
     use std::net::TcpListener;

--- a/veecle-net-utils/src/lib.rs
+++ b/veecle-net-utils/src/lib.rs
@@ -8,6 +8,7 @@
 //! - `tokio`: Enable async networking support (requires Tokio). Default: disabled.
 
 #![forbid(unsafe_code)]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 mod address;
 #[cfg(feature = "tokio")]

--- a/veecle-os-data-support-can/src/bits.rs
+++ b/veecle-os-data-support-can/src/bits.rs
@@ -159,6 +159,7 @@ pub fn write_little_endian_signed(bytes: &mut [u8], offset: usize, length: usize
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use test_case::test_case;
 

--- a/veecle-os-data-support-can/src/frame.rs
+++ b/veecle-os-data-support-can/src/frame.rs
@@ -92,6 +92,7 @@ impl core::fmt::Debug for Frame {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use crate::Frame;
 

--- a/veecle-os-data-support-can/src/id.rs
+++ b/veecle-os-data-support-can/src/id.rs
@@ -197,6 +197,7 @@ impl<'de> serde::Deserialize<'de> for PackedId {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::format;
     use std::string::ToString;

--- a/veecle-os-data-support-can/src/lib.rs
+++ b/veecle-os-data-support-can/src/lib.rs
@@ -1,6 +1,7 @@
 //! Support for working with CAN messages within a runtime instance.
 #![no_std]
 #![forbid(unsafe_code)]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 #[cfg(test)]
 extern crate std;

--- a/veecle-os-data-support-someip/src/lib.rs
+++ b/veecle-os-data-support-someip/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 #![forbid(unsafe_code)]
-// Set by `cargo-llvm-cov` https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#exclude-code-from-coverage
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 #[cfg(test)]

--- a/veecle-os-runtime-macros/src/lib.rs
+++ b/veecle-os-runtime-macros/src/lib.rs
@@ -1,6 +1,7 @@
 //! This crate provides runtime macros.
 
 #![forbid(unsafe_code)]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 mod actor;
 mod storable;
@@ -168,6 +169,7 @@ fn veecle_os_runtime_path() -> syn::Result<syn::Path> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::fs::File;
 

--- a/veecle-os-runtime/src/actor.rs
+++ b/veecle-os-runtime/src/actor.rs
@@ -229,6 +229,7 @@ where
     S: Datastore,
 {
     #[cfg(test)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn increment_generation(self) {
         self.source().increment_generation()
     }
@@ -388,6 +389,7 @@ impl IsActorResult for Infallible {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use core::future::Future;
     use core::pin::pin;

--- a/veecle-os-runtime/src/datastore/combined_readers.rs
+++ b/veecle-os-runtime/src/datastore/combined_readers.rs
@@ -114,6 +114,7 @@ impl_combined_reader_helper!(
 );
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use core::pin::pin;
     use futures::FutureExt;

--- a/veecle-os-runtime/src/datastore/exclusive_reader.rs
+++ b/veecle-os-runtime/src/datastore/exclusive_reader.rs
@@ -158,6 +158,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use core::pin::pin;
     use futures::FutureExt;

--- a/veecle-os-runtime/src/datastore/generational.rs
+++ b/veecle-os-runtime/src/datastore/generational.rs
@@ -132,6 +132,7 @@ pub(crate) struct MissedUpdate {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::cell::Cell;
     use std::future::Future;

--- a/veecle-os-runtime/src/datastore/initialized_reader.rs
+++ b/veecle-os-runtime/src/datastore/initialized_reader.rs
@@ -138,6 +138,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use core::pin::pin;
     use futures::FutureExt;

--- a/veecle-os-runtime/src/datastore/reader.rs
+++ b/veecle-os-runtime/src/datastore/reader.rs
@@ -160,6 +160,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use core::pin::pin;
     use futures::FutureExt;

--- a/veecle-os-runtime/src/datastore/writer.rs
+++ b/veecle-os-runtime/src/datastore/writer.rs
@@ -171,6 +171,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use crate::datastore::{Slot, Storable, Writer, generational};
     use core::pin::pin;

--- a/veecle-os-runtime/src/heapfree_executor.rs
+++ b/veecle-os-runtime/src/heapfree_executor.rs
@@ -379,6 +379,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use core::pin::pin;
     use core::task::Poll;

--- a/veecle-os-runtime/src/lib.rs
+++ b/veecle-os-runtime/src/lib.rs
@@ -95,6 +95,7 @@
 
 #![cfg_attr(docsrs, allow(internal_features))]
 #![cfg_attr(docsrs, feature(rustdoc_internals))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![no_std]
 
 #[cfg(test)]

--- a/veecle-os-runtime/src/memory_pool.rs
+++ b/veecle-os-runtime/src/memory_pool.rs
@@ -309,6 +309,7 @@ impl<T> Drop for Chunk<'_, T> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod test {
     use std::format;
     use std::sync::atomic::AtomicUsize;

--- a/veecle-os-test/src/execute.rs
+++ b/veecle-os-test/src/execute.rs
@@ -150,6 +150,7 @@ macro_rules! execute {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     #[veecle_os_runtime::actor]
     async fn contextual_actor<T: core::fmt::Debug>(

--- a/veecle-os-test/src/lib.rs
+++ b/veecle-os-test/src/lib.rs
@@ -62,6 +62,7 @@
 //! ```
 
 #![forbid(unsafe_code)]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 #[doc(hidden)]
 mod execute;

--- a/veecle-osal-api/src/lib.rs
+++ b/veecle-osal-api/src/lib.rs
@@ -1,7 +1,6 @@
 //! The Veecle OS operating system abstraction layer API.
 
 #![no_std]
-// Set by `cargo-llvm-cov` https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#exclude-code-from-coverage
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 #[cfg(any(test, feature = "test-suites"))]

--- a/veecle-osal-api/src/time/timeout.rs
+++ b/veecle-osal-api/src/time/timeout.rs
@@ -26,6 +26,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use futures::executor::block_on;
 

--- a/veecle-osal-std-macros/src/lib.rs
+++ b/veecle-osal-std-macros/src/lib.rs
@@ -1,5 +1,7 @@
 //! `veecle-osal-std` macros.
 
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 mod main_impl;
 
 use proc_macro::TokenStream;
@@ -74,6 +76,7 @@ fn crate_path(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::fs::File;
 

--- a/veecle-telemetry/src/lib.rs
+++ b/veecle-telemetry/src/lib.rs
@@ -80,6 +80,7 @@
 //! ensuring zero runtime overhead in production builds where telemetry is not needed.
 
 #![no_std]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/veecle-telemetry/src/protocol.rs
+++ b/veecle-telemetry/src/protocol.rs
@@ -421,6 +421,7 @@ pub struct SpanAddLinkMessage {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     #[cfg(feature = "alloc")]
     use alloc::string::String;


### PR DESCRIPTION
The inclusion of test code skews the coverage data. Examples and integration tests are already ignored by default by llvm-cov. We already ignore some test code, this PR brings consistency to all of our tests.

Tests in test-crates are not included as they don't contain any exposed functionality.

Fixes: DEV-1070