### PR TITLE
refactor(orchestrator): use actor model for conductor

### DIFF
--- a/veecle-orchestrator/src/api.rs
+++ b/veecle-orchestrator/src/api.rs
@@ -175,11 +175,11 @@ async fn handle_request(
             return Ok((encode(())?, Some(responder)));
         }
         Request::Remove(id) => {
-            conductor.remove(id).wrap_err("removing instance")?;
+            conductor.remove(id).await.wrap_err("removing instance")?;
             encode(())?
         }
         Request::Start(id) => {
-            conductor.start(id).wrap_err("starting instance")?;
+            conductor.start(id).await.wrap_err("starting instance")?;
             encode(())?
         }
         Request::Stop(id) => {
@@ -194,7 +194,7 @@ async fn handle_request(
             encode(())?
         }
         Request::Info => encode(Info {
-            runtimes: conductor.info(),
+            runtimes: conductor.info().await?,
             links: distributor.info().await?,
         })?,
         Request::Clear => {


### PR DESCRIPTION
This simplifies the concurrency handling, making it much easier to integrate a secondary path for `RuntimeInstance`s to also send commands to modify the conductor state.