### PR TITLE
chore: fix runtime telemetry messages

### DIFF
--- a/veecle-os-runtime/src/datastore/exclusive_reader.rs
+++ b/veecle-os-runtime/src/datastore/exclusive_reader.rs
@@ -81,7 +81,7 @@ where
 
             // TODO(DEV-532): add debug format
             #[cfg(feature = "veecle-telemetry")]
-            veecle_telemetry::trace!("Slot read.", type_name = self.waiter.inner_type_name());
+            veecle_telemetry::trace!("Slot read", type_name = self.waiter.inner_type_name());
             f(value)
         })
     }

--- a/veecle-os-runtime/src/datastore/initialized_reader.rs
+++ b/veecle-os-runtime/src/datastore/initialized_reader.rs
@@ -76,7 +76,7 @@ where
 
             // TODO(DEV-532): add debug format
             #[cfg(feature = "veecle-telemetry")]
-            veecle_telemetry::trace!("Slot read.", type_name = self.waiter.inner_type_name());
+            veecle_telemetry::trace!("Slot read", type_name = self.waiter.inner_type_name());
             f(value)
         })
     }

--- a/veecle-os-runtime/src/datastore/reader.rs
+++ b/veecle-os-runtime/src/datastore/reader.rs
@@ -87,7 +87,7 @@ where
 
             // TODO(DEV-532): add debug format
             #[cfg(feature = "veecle-telemetry")]
-            veecle_telemetry::trace!("Slot read.", type_name = self.waiter.inner_type_name());
+            veecle_telemetry::trace!("Slot read", type_name = self.waiter.inner_type_name());
             f(value)
         })
     }

--- a/veecle-os-runtime/src/datastore/writer.rs
+++ b/veecle-os-runtime/src/datastore/writer.rs
@@ -134,7 +134,7 @@ where
 
             // TODO(DEV-532): add debug format
             #[cfg(feature = "veecle-telemetry")]
-            veecle_telemetry::trace!("Type update.", type_name);
+            veecle_telemetry::trace!("Slot modified", type_name);
         });
         self.slot.increment_generation();
     }
@@ -150,7 +150,7 @@ where
             let value = value.as_ref();
             // TODO(DEV-532): add debug format
             #[cfg(feature = "veecle-telemetry")]
-            veecle_telemetry::trace!("Slot read.", type_name);
+            veecle_telemetry::trace!("Slot read", type_name);
             f(value)
         })
     }


### PR DESCRIPTION
Remove periods as these are just fragments, not full sentences. Adjust the modification message to be more understandable.