### PR TITLE
chore: block dependabot `embedded-io-*` updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,11 @@ updates:
       # Embassy doesn't support heapless versions >=0.9.0.
       - dependency-name: "heapless"
         versions: [">=0.9.0"]
+
       # DEV-1037, updating requires API breaking changes.
+      - dependency-name: "embedded-io"
+        versions: [">=0.7.0"]
+      - dependency-name: "embedded-io-adapters"
+        versions: [">=0.7.0"]
       - dependency-name: "embedded-io-async"
         versions: [">=0.7.0"]


### PR DESCRIPTION
Similar to the existing `embedded-io-async` block we want to do these as a purposeful combined change as they're exposed to the public API.