### PR TITLE
test(telemetry): verify output structure in trailing comma test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5133,6 +5133,7 @@ dependencies = [
  "hex",
  "indoc",
  "pin-project",
+ "pretty_assertions",
  "rand 0.9.2",
  "serde",
  "serde_json",

--- a/veecle-telemetry/Cargo.toml
+++ b/veecle-telemetry/Cargo.toml
@@ -26,6 +26,7 @@ veecle-telemetry-macros = { workspace = true }
 
 [dev-dependencies]
 indoc = { workspace = true }
+pretty_assertions = { workspace = true, features = ["std"] }
 serial_test = { workspace = true }
 tokio = { workspace = true }
 veecle-telemetry = { path = ".", features = ["enable", "std"] }

--- a/veecle-telemetry/tests/lib.rs
+++ b/veecle-telemetry/tests/lib.rs
@@ -9,8 +9,10 @@
 use std::time::Duration;
 
 use indoc::indoc;
+use pretty_assertions::assert_eq;
 use serial_test::serial;
 use tokio::runtime::Builder;
+
 use veecle_telemetry::future::FutureExt;
 use veecle_telemetry::protocol::Severity;
 use veecle_telemetry::test_helpers::format_telemetry_tree;
@@ -442,6 +444,20 @@ fn test_trailing_comma_support() {
         veecle_telemetry::event!("empty event",);
     }
 
-    let messages = exporter.take_messages();
-    assert_eq!(messages.len(), 12);
+    let graph = format_telemetry_tree(exporter.take_messages());
+    assert_eq!(
+        graph,
+        indoc! {r#"
+            root span [root_attr=123]
+            root span [root_attr=123]
+            + log: [Trace] empty log []
+            + log: [Trace] empty log []
+            + log: [Info] single attr [value=1]
+            + log: [Info] single attr [value=1]
+            + log: [Debug] multiple attrs [key1="val1", key2=42]
+            + log: [Debug] multiple attrs [key1="val1", key2=42]
+            + log: [Warn] mixed syntax [identifier="test", literal=true]
+            + log: [Warn] mixed syntax [identifier="test", literal=true]
+        "#}
+    );
 }


### PR DESCRIPTION
There's no easy way to tell why the numbers in the original assertion would change. By having the textual rendering of what got logged it's easier to see why it changes when the telemetry API changes affect it.

Uses `pretty-assertions` because that has a good multiline string diff rendering.