### PR TITLE
feat(telemetry)!: add `Span::context` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * **breaking** Telemetry functionality is now always compiled into the runtime.
   The `veecle-telemetry` feature flag has been removed from `veecle-os-runtime`.
   Use the `telemetry-enable` feature flag on `veecle-os` to control telemetry behavior.
+* **breaking** Replaced `SpanContext::from_span` with `Span::context` method.
 * Added `ThreadAbstraction` trait to OSAL for querying current thread id.
 * Fixed `veecle_os::telemetry::instrument` macro to automatically resolve correct crate paths for the facade.
 

--- a/veecle-telemetry/src/id.rs
+++ b/veecle-telemetry/src/id.rs
@@ -19,7 +19,6 @@ use core::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use crate::Span;
 use crate::collector::get_collector;
 #[cfg(feature = "enable")]
 use crate::span::CURRENT_SPAN;
@@ -196,34 +195,6 @@ impl SpanContext {
         Self {
             trace_id: TraceId::generate(),
             span_id: SpanId(0),
-        }
-    }
-
-    /// Creates a `SpanContext` from the given [`Span`]. If the `Span` is a noop span,
-    /// this function will return `None`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use veecle_telemetry::*;
-    ///
-    /// let span = Span::root("root", SpanContext::generate(), &[]);
-    /// let span_context = SpanContext::from_span(&span);
-    /// ```
-    ///
-    /// [`Span`]: crate::Span
-    pub fn from_span(span: &Span) -> Option<Self> {
-        #[cfg(not(feature = "enable"))]
-        {
-            let _ = span;
-            None
-        }
-
-        #[cfg(feature = "enable")]
-        {
-            let inner = span.inner.as_ref()?;
-
-            Some(inner.context)
         }
     }
 


### PR DESCRIPTION
This is more readable in code that is manually querying the span context for a span they hold.