### PR TITLE
refactor(runtime): pass span context explicitly in datastore operations

### DIFF
--- a/veecle-os-runtime/src/datastore/exclusive_reader.rs
+++ b/veecle-os-runtime/src/datastore/exclusive_reader.rs
@@ -86,9 +86,11 @@ where
     }
 
     /// Takes the current value of the type, leaving behind `None`.
-    #[veecle_telemetry::instrument]
     pub fn take(&mut self) -> Option<T::DataType> {
-        let value = self.waiter.take();
+        let span = veecle_telemetry::span!("take");
+        let _guard = span.enter();
+
+        let value = self.waiter.take(span.context());
 
         // TODO(DEV-532): add debug format
         veecle_telemetry::trace!(

--- a/veecle-os-runtime/src/datastore/slot/waiter.rs
+++ b/veecle-os-runtime/src/datastore/slot/waiter.rs
@@ -70,7 +70,12 @@ where
     T: Storable + 'static,
 {
     /// Takes the current value of the slot, leaving behind `None`.
-    pub(crate) fn take(&mut self) -> Option<T::DataType> {
-        self.slot.take()
+    ///
+    /// Stores the provided `span_context` to connect this write to the next read operation.
+    pub(crate) fn take(
+        &mut self,
+        span_context: Option<veecle_telemetry::SpanContext>,
+    ) -> Option<T::DataType> {
+        self.slot.take(span_context)
     }
 }


### PR DESCRIPTION
Required so the implicit APIs can be removed from `veecle-telemetry`.