### PR TITLE
feat(telemetry)!: replace execution id with thread id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   Use the `telemetry-enable` feature flag on `veecle-os` to control telemetry behavior.
 * **breaking** Removed `Span::root` method and `root_span!` macro; root spans should use `Span::new` and `span!` instead.
 * **breaking** Replaced `SpanContext::from_span` with `Span::context` method.
+* **breaking** Telemetry execution id is replaced by separate thread and process ids to uniquely identify thread/task combinations.
 * Added `ThreadAbstraction` trait to OSAL for querying current thread id.
 * Updated MSRV to 1.90.
 * Fixed `veecle_os::telemetry::instrument` macro to automatically resolve correct crate paths for the facade.

--- a/veecle-ipc/src/connector.rs
+++ b/veecle-ipc/src/connector.rs
@@ -111,7 +111,7 @@ impl Connector {
     /// let connector = veecle_ipc::Connector::connect().await;
     ///
     /// veecle_os::telemetry::collector::set_exporter(
-    ///     veecle_os::telemetry::protocol::ExecutionId::random(&mut rand::rng()),
+    ///     veecle_os::telemetry::collector::ProcessId::random(&mut rand::rng()),
     ///     Box::leak(Box::new(connector.exporter())),
     /// )?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())

--- a/veecle-os-examples/embassy-std/src/main.rs
+++ b/veecle-os-examples/embassy-std/src/main.rs
@@ -17,7 +17,7 @@ async fn run() {
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     veecle_os::telemetry::collector::set_exporter(
-        veecle_os::telemetry::protocol::ExecutionId::random(&mut rand::rng()),
+        veecle_os::telemetry::collector::ProcessId::random(&mut rand::rng()),
         &veecle_os::telemetry::collector::ConsoleJsonExporter,
     )
     .unwrap();

--- a/veecle-os-examples/freertos-linux/src/bin/alloc.rs
+++ b/veecle-os-examples/freertos-linux/src/bin/alloc.rs
@@ -20,7 +20,7 @@ async fn alloc_stat_actor() -> Infallible {
 
 pub fn main() -> ! {
     veecle_os::telemetry::collector::set_exporter(
-        veecle_os::telemetry::protocol::ExecutionId::random(&mut rand::rng()),
+        veecle_os::telemetry::collector::ProcessId::random(&mut rand::rng()),
         &veecle_os::telemetry::collector::ConsoleJsonExporter,
     )
     .unwrap();

--- a/veecle-os-examples/freertos-linux/src/bin/queues.rs
+++ b/veecle-os-examples/freertos-linux/src/bin/queues.rs
@@ -32,7 +32,7 @@ async fn queue_actor(
 
 fn main() {
     veecle_os::telemetry::collector::set_exporter(
-        veecle_os::telemetry::protocol::ExecutionId::random(&mut rand::rng()),
+        veecle_os::telemetry::collector::ProcessId::random(&mut rand::rng()),
         &veecle_os::telemetry::collector::ConsoleJsonExporter,
     )
     .unwrap();

--- a/veecle-os-examples/freertos-linux/src/bin/time.rs
+++ b/veecle-os-examples/freertos-linux/src/bin/time.rs
@@ -9,7 +9,7 @@ static GLOBAL: FreeRtosAllocator = unsafe { FreeRtosAllocator::new() };
 /// An example of using the time abstraction within a FreeRTOS task.
 pub fn main() -> ! {
     veecle_os::telemetry::collector::set_exporter(
-        veecle_os::telemetry::protocol::ExecutionId::random(&mut rand::rng()),
+        veecle_os::telemetry::collector::ProcessId::random(&mut rand::rng()),
         &veecle_os::telemetry::collector::ConsoleJsonExporter,
     )
     .unwrap();

--- a/veecle-os-examples/orchestrator-ipc/src/bin/ping.rs
+++ b/veecle-os-examples/orchestrator-ipc/src/bin/ping.rs
@@ -5,7 +5,7 @@ async fn main() {
     let connector = veecle_ipc::Connector::connect().await;
 
     veecle_os::telemetry::collector::set_exporter(
-        veecle_os::telemetry::protocol::ExecutionId::random(&mut rand::rng()),
+        veecle_os::telemetry::collector::ProcessId::random(&mut rand::rng()),
         Box::leak(Box::new(connector.exporter())),
     )
     .unwrap();

--- a/veecle-os-examples/orchestrator-ipc/src/bin/pong.rs
+++ b/veecle-os-examples/orchestrator-ipc/src/bin/pong.rs
@@ -5,7 +5,7 @@ async fn main() {
     let connector = veecle_ipc::Connector::connect().await;
 
     veecle_os::telemetry::collector::set_exporter(
-        veecle_os::telemetry::protocol::ExecutionId::random(&mut rand::rng()),
+        veecle_os::telemetry::collector::ProcessId::random(&mut rand::rng()),
         Box::leak(Box::new(connector.exporter())),
     )
     .unwrap();

--- a/veecle-os-examples/orchestrator-ipc/src/bin/trace.rs
+++ b/veecle-os-examples/orchestrator-ipc/src/bin/trace.rs
@@ -5,7 +5,7 @@ async fn main() {
     let connector = veecle_ipc::Connector::connect().await;
 
     veecle_os::telemetry::collector::set_exporter(
-        veecle_os::telemetry::protocol::ExecutionId::random(&mut rand::rng()),
+        veecle_os::telemetry::collector::ProcessId::random(&mut rand::rng()),
         Box::leak(Box::new(connector.exporter())),
     )
     .unwrap();

--- a/veecle-os-examples/orchestrator-ipc/src/bin/useless-machine.rs
+++ b/veecle-os-examples/orchestrator-ipc/src/bin/useless-machine.rs
@@ -49,7 +49,7 @@ async fn main() {
     let connector = veecle_ipc::Connector::connect().await;
 
     veecle_os::telemetry::collector::set_exporter(
-        veecle_os::telemetry::protocol::ExecutionId::random(&mut rand::rng()),
+        veecle_os::telemetry::protocol::ProcessId::random(&mut rand::rng()),
         Box::leak(Box::new(connector.exporter())),
     )
     .unwrap();

--- a/veecle-osal-std-macros/src/main_impl.rs
+++ b/veecle-osal-std-macros/src/main_impl.rs
@@ -70,7 +70,7 @@ fn impl_main(
         quote!(
             // Initialize `veecle-telemetry` with a random execution ID and console JSON exporter.
             #veecle_telemetry_path::collector::set_exporter(
-                #veecle_telemetry_path::protocol::ExecutionId::random(
+                #veecle_telemetry_path::collector::ProcessId::random(
                     &mut #veecle_osal_std_path::reexports::rand::rng(),
                 ),
                 &#veecle_telemetry_path::collector::ConsoleJsonExporter

--- a/veecle-telemetry-ui/examples/continuous.rs
+++ b/veecle-telemetry-ui/examples/continuous.rs
@@ -9,8 +9,7 @@ use std::convert::Infallible;
 
 use veecle_os_runtime::{Reader, Writer};
 use veecle_osal_std::time::{Duration, Time, TimeAbstraction};
-use veecle_telemetry::collector::ConsoleJsonExporter;
-use veecle_telemetry::protocol::ExecutionId;
+use veecle_telemetry::collector::{ConsoleJsonExporter, ProcessId};
 
 use crate::common::{ConcreteTraceActor, Ping, Pong, PongActor, ping_loop};
 
@@ -34,8 +33,8 @@ async fn ping_actor(
 
 #[veecle_osal_std::main]
 async fn main() {
-    let execution_id = ExecutionId::random(&mut rand::rng());
-    veecle_telemetry::collector::set_exporter(execution_id, &ConsoleJsonExporter)
+    let process_id = ProcessId::random(&mut rand::rng());
+    veecle_telemetry::collector::set_exporter(process_id, &ConsoleJsonExporter)
         .expect("exporter was not set yet");
 
     veecle_os_runtime::execute! {

--- a/veecle-telemetry-ui/examples/remote.rs
+++ b/veecle-telemetry-ui/examples/remote.rs
@@ -10,8 +10,7 @@
 use std::convert::Infallible;
 
 use veecle_os_runtime::{Reader, Writer};
-use veecle_telemetry::collector::ConsoleJsonExporter;
-use veecle_telemetry::protocol::ExecutionId;
+use veecle_telemetry::collector::{ConsoleJsonExporter, ProcessId};
 
 use crate::common::{ConcreteTraceActor, Ping, Pong, PongActor, ping_loop};
 
@@ -34,8 +33,8 @@ pub async fn ping_actor(mut ping: Writer<'_, Ping>, mut pong: Reader<'_, Pong>) 
 
 #[veecle_osal_std::main]
 async fn main() {
-    let execution_id = ExecutionId::random(&mut rand::rng());
-    veecle_telemetry::collector::set_exporter(execution_id, &ConsoleJsonExporter)
+    let process_id = ProcessId::random(&mut rand::rng());
+    veecle_telemetry::collector::set_exporter(process_id, &ConsoleJsonExporter)
         .expect("exporter was not set yet");
 
     veecle_os_runtime::execute! {

--- a/veecle-telemetry-ui/src/store/mod.rs
+++ b/veecle-telemetry-ui/src/store/mod.rs
@@ -169,8 +169,8 @@ impl Store {
         self.ensure_program_span();
 
         let InstanceMessage {
-            // TODO(DEV-605): support filtering by execution.
-            execution: _,
+            // TODO(DEV-605): support filtering by thread.
+            thread: _,
             message,
         } = instance_message;
 

--- a/veecle-telemetry/examples/async.rs
+++ b/veecle-telemetry/examples/async.rs
@@ -2,14 +2,13 @@
 
 use std::time::Duration;
 
-use veecle_telemetry::collector::ConsoleJsonExporter;
-use veecle_telemetry::protocol::ExecutionId;
+use veecle_telemetry::collector::{ConsoleJsonExporter, ProcessId};
 use veecle_telemetry::{CurrentSpan, Span};
 
 #[tokio::main]
 async fn main() {
-    let execution_id = ExecutionId::random(&mut rand::rng());
-    veecle_telemetry::collector::set_exporter(execution_id, &ConsoleJsonExporter)
+    let process_id = ProcessId::random(&mut rand::rng());
+    veecle_telemetry::collector::set_exporter(process_id, &ConsoleJsonExporter)
         .expect("exporter was not set yet");
 
     let _span = Span::new("main", &[]).entered();

--- a/veecle-telemetry/examples/basic.rs
+++ b/veecle-telemetry/examples/basic.rs
@@ -1,12 +1,11 @@
 #![expect(missing_docs, reason = "example")]
 
 use veecle_telemetry::Span;
-use veecle_telemetry::collector::ConsoleJsonExporter;
-use veecle_telemetry::protocol::ExecutionId;
+use veecle_telemetry::collector::{ConsoleJsonExporter, ProcessId};
 
 fn main() {
-    let execution_id = ExecutionId::random(&mut rand::rng());
-    veecle_telemetry::collector::set_exporter(execution_id, &ConsoleJsonExporter)
+    let process_id = ProcessId::random(&mut rand::rng());
+    veecle_telemetry::collector::set_exporter(process_id, &ConsoleJsonExporter)
         .expect("exporter was not set yet");
 
     let _span = Span::new("main", &[]).entered();

--- a/veecle-telemetry/src/collector/json_exporter.rs
+++ b/veecle-telemetry/src/collector/json_exporter.rs
@@ -6,11 +6,10 @@ use crate::protocol::InstanceMessage;
 /// # Examples
 ///
 /// ```rust
-/// use veecle_telemetry::collector::{ConsoleJsonExporter, set_exporter};
-/// use veecle_telemetry::protocol::ExecutionId;
+/// use veecle_telemetry::collector::{ConsoleJsonExporter, set_exporter, ProcessId};
 ///
-/// let execution_id = ExecutionId::random(&mut rand::rng());
-/// set_exporter(execution_id, &ConsoleJsonExporter).unwrap();
+/// let process_id = ProcessId::random(&mut rand::rng());
+/// set_exporter(process_id, &ConsoleJsonExporter).unwrap();
 /// ```
 #[derive(Debug)]
 pub struct ConsoleJsonExporter;

--- a/veecle-telemetry/src/collector/mod.rs
+++ b/veecle-telemetry/src/collector/mod.rs
@@ -39,13 +39,14 @@ pub use json_exporter::ConsoleJsonExporter;
 pub use test_exporter::TestExporter;
 
 use crate::TraceId;
-#[cfg(feature = "enable")]
-use crate::protocol::ExecutionId;
 use crate::protocol::InstanceMessage;
+#[cfg(feature = "enable")]
+pub use crate::protocol::ProcessId;
 #[cfg(feature = "enable")]
 use crate::protocol::{
     LogMessage, SpanAddEventMessage, SpanAddLinkMessage, SpanCloseMessage, SpanCreateMessage,
-    SpanEnterMessage, SpanExitMessage, SpanSetAttributeMessage, TelemetryMessage, TracingMessage,
+    SpanEnterMessage, SpanExitMessage, SpanSetAttributeMessage, TelemetryMessage, ThreadId,
+    TracingMessage,
 };
 
 /// Trait for exporting telemetry data to external systems.
@@ -94,7 +95,7 @@ pub struct Collector {
 #[cfg(feature = "enable")]
 #[derive(Debug)]
 struct CollectorInner {
-    execution_id: ExecutionId,
+    process_id: ProcessId,
 
     exporter: &'static (dyn Export + Sync),
 
@@ -116,7 +117,7 @@ impl Export for NopExporter {
 #[cfg(feature = "enable")]
 static mut GLOBAL_COLLECTOR: Collector = Collector {
     inner: CollectorInner {
-        execution_id: ExecutionId::from_raw(0),
+        process_id: ProcessId::from_raw(0),
         exporter: &NO_EXPORTER,
 
         trace_id_prefix: 0,
@@ -126,7 +127,7 @@ static mut GLOBAL_COLLECTOR: Collector = Collector {
 static NO_COLLECTOR: Collector = Collector {
     #[cfg(feature = "enable")]
     inner: CollectorInner {
-        execution_id: ExecutionId::from_raw(0),
+        process_id: ProcessId::from_raw(0),
         exporter: &NO_EXPORTER,
 
         trace_id_prefix: 0,
@@ -150,13 +151,13 @@ const INITIALIZING: usize = 1;
 #[cfg(feature = "enable")]
 const INITIALIZED: usize = 2;
 
-/// Initializes the collector with the given Exporter and [`ExecutionId`].
+/// Initializes the collector with the given Exporter and [`ProcessId`].
 ///
-/// An [`ExecutionId`] should never be re-used as it's used to collect metadata about the execution and to generate
+/// A [`ProcessId`] should never be re-used as it's used to collect metadata about the execution and to generate
 /// [`TraceId`]s which need to be globally unique.
 #[cfg(feature = "enable")]
 pub fn set_exporter(
-    execution_id: ExecutionId,
+    process_id: ProcessId,
     exporter: &'static (dyn Export + Sync),
 ) -> Result<(), SetExporterError> {
     if GLOBAL_INIT
@@ -169,7 +170,7 @@ pub fn set_exporter(
         .is_ok()
     {
         // SAFETY: this is guarded by the atomic
-        unsafe { GLOBAL_COLLECTOR = Collector::new(execution_id, exporter) }
+        unsafe { GLOBAL_COLLECTOR = Collector::new(process_id, exporter) }
         GLOBAL_INIT.store(INITIALIZED, Ordering::Release);
 
         Ok(())
@@ -227,14 +228,13 @@ impl error::Error for SetExporterError {}
 
 impl Collector {
     #[cfg(feature = "enable")]
-    fn new(execution_id: ExecutionId, exporter: &'static (dyn Export + Sync)) -> Self {
-        let execution_id_raw = *execution_id;
-        let trace_id_prefix = (execution_id_raw >> 64) as u64;
-        let initial_counter_value = execution_id_raw as u64;
+    fn new(process_id: ProcessId, exporter: &'static (dyn Export + Sync)) -> Self {
+        let trace_id_prefix = (process_id.to_raw() >> 64) as u64;
+        let initial_counter_value = process_id.to_raw() as u64;
 
         Self {
             inner: CollectorInner {
-                execution_id,
+                process_id,
                 exporter,
                 trace_id_prefix,
                 trace_id_counter: AtomicU64::new(initial_counter_value),
@@ -271,9 +271,11 @@ impl Collector {
     /// # Examples
     ///
     /// ```rust
+    /// use core::num::NonZeroU64;
     /// use veecle_telemetry::collector::get_collector;
     /// use veecle_telemetry::protocol::{
-    ///     ExecutionId,
+    ///     ThreadId,
+    ///     ProcessId,
     ///     InstanceMessage,
     ///     TelemetryMessage,
     ///     TimeSyncMessage,
@@ -281,7 +283,7 @@ impl Collector {
     ///
     /// let collector = get_collector();
     /// let message = InstanceMessage {
-    ///     execution: ExecutionId::from_raw(1),
+    ///     thread: ThreadId::from_raw(ProcessId::from_raw(1), NonZeroU64::new(1).unwrap()),
     ///     message: TelemetryMessage::TimeSync(TimeSyncMessage {
     ///         local_timestamp: 0,
     ///         since_epoch: 0,
@@ -332,7 +334,7 @@ impl Collector {
     #[inline]
     pub(crate) fn log_message(&self, log: LogMessage<'_>) {
         self.inner.exporter.export(InstanceMessage {
-            execution: self.inner.execution_id,
+            thread: ThreadId::current(self.inner.process_id),
             message: TelemetryMessage::Log(log),
         });
     }
@@ -340,7 +342,7 @@ impl Collector {
     #[inline]
     fn tracing_message(&self, message: TracingMessage<'_>) {
         self.inner.exporter.export(InstanceMessage {
-            execution: self.inner.execution_id,
+            thread: ThreadId::current(self.inner.process_id),
             message: TelemetryMessage::Tracing(message),
         });
     }

--- a/veecle-telemetry/src/id.rs
+++ b/veecle-telemetry/src/id.rs
@@ -23,6 +23,40 @@ use crate::collector::get_collector;
 #[cfg(feature = "enable")]
 use crate::span::CURRENT_SPAN;
 
+/// A globally-unique id identifying a process.
+///
+/// The primary purpose of this id is to provide a globally-unique context within which
+/// [`ThreadId`]s and [`SpanContext`]s are guaranteed to be unique. On a normal operating system
+/// that is the process, on other systems it should be whatever is the closest equivalent, e.g. for
+/// most embedded setups it should be unique for each time the system is restarted.
+///
+/// [`ThreadId`]: crate::protocol::ThreadId
+#[derive(
+    Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Serialize, Deserialize,
+)]
+pub struct ProcessId(u128);
+
+impl ProcessId {
+    /// Uses a random number generator to generate the [`ProcessId`].
+    pub fn random(rng: &mut impl rand::Rng) -> Self {
+        Self(rng.random())
+    }
+
+    /// Creates a [`ProcessId`] from a raw value
+    ///
+    /// Extra care needs to be taken that this is not a constant value or re-used in any way.
+    ///
+    /// When possible prefer using [`ProcessId::random`].
+    pub const fn from_raw(raw: u128) -> Self {
+        Self(raw)
+    }
+
+    /// Returns the raw value of this id.
+    pub fn to_raw(self) -> u128 {
+        self.0
+    }
+}
+
 /// An identifier for a trace, which groups a set of related spans together.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct TraceId(pub u128);

--- a/veecle-telemetry/src/lib.rs
+++ b/veecle-telemetry/src/lib.rs
@@ -27,11 +27,11 @@
 //!
 //! ```rust
 //! use veecle_telemetry::collector::{ConsoleJsonExporter, set_exporter};
-//! use veecle_telemetry::protocol::ExecutionId;
+//! use veecle_telemetry::ProcessId;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let execution_id = ExecutionId::random(&mut rand::rng());
-//! set_exporter(execution_id, &ConsoleJsonExporter)?;
+//! let process_id = ProcessId::random(&mut rand::rng());
+//! set_exporter(process_id, &ConsoleJsonExporter)?;
 //! # Ok(())
 //! # }
 //! ```
@@ -111,7 +111,7 @@ pub mod to_static;
 pub mod types;
 pub mod value;
 
-pub use id::{SpanContext, SpanId, TraceId};
+pub use id::{ProcessId, SpanContext, SpanId, TraceId};
 pub use span::{CurrentSpan, Span, SpanGuard, SpanGuardRef};
 pub use value::{KeyValue, Value};
 pub use veecle_telemetry_macros::instrument;

--- a/veecle-telemetry/src/protocol.rs
+++ b/veecle-telemetry/src/protocol.rs
@@ -12,11 +12,11 @@
 //! - **Tracing Messages** - Distributed tracing with spans, events, and links
 //! - **Time Sync Messages** - Time synchronization between systems
 //!
-//! # Execution Tracking
+//! # Thread Tracking
 //!
-//! Each message is associated with an [`ExecutionId`] that uniquely identifies
-//! the execution context.
-//! This allows telemetry data from multiple executions to be correlated and analyzed separately.
+//! Each message is associated with an [`ThreadId`] that uniquely identifies
+//! the thread it came from (globally unique across all processes).
+//! This allows telemetry data from multiple threads to be correlated and analyzed separately.
 //!
 //! # Serialization
 //!
@@ -25,12 +25,12 @@
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-use core::ops::Deref;
+use core::num::NonZeroU64;
 
 use serde::{Deserialize, Serialize};
 
 use crate::SpanContext;
-use crate::id::{SpanId, TraceId};
+pub use crate::id::{ProcessId, SpanId, TraceId};
 #[cfg(feature = "alloc")]
 use crate::to_static::ToStatic;
 use crate::types::{ListType, StringType, list_from_slice};
@@ -56,45 +56,59 @@ impl ToStatic for AttributeListType<'_> {
     }
 }
 
-/// An Id uniquely identifying an execution.
+/// A globally-unique id identifying a thread within a specific process.
 ///
-/// An [`ExecutionId`] should never be re-used as it's used to collect metadata about the execution and to generate
-/// [`TraceId`]s which need to be globally unique.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
-pub struct ExecutionId(u128);
+/// The primary purpose of this id is to allow the consumer of telemetry messages to associate
+/// spans with the callstack they came from to reconstruct parent-child relationships. On a normal
+/// operating system this is the thread, on other systems it should be whatever is the closest
+/// equivalent, e.g. for FreeRTOS it would be a task. On a single threaded bare-metal system it
+/// would be a constant as there is only the one callstack.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+pub struct ThreadId {
+    /// The globally-unique id for the process this thread is within.
+    pub process: ProcessId,
 
-impl ExecutionId {
-    /// Uses a random generator to generate the [`ExecutionId`].
-    pub fn random(rng: &mut impl rand::Rng) -> Self {
-        Self(rng.random())
-    }
+    /// The process-unique id for this thread within the process.
+    raw: NonZeroU64,
+}
 
-    /// Creates an [`ExecutionId`] from a raw value, extra care needs to be taken that this is not a constant value or
-    /// re-used in any way.
+impl ThreadId {
+    /// Creates a [`ThreadId`] from a raw value.
     ///
-    /// When possible prefer using [`ExecutionId::random`].
-    pub const fn from_raw(raw: u128) -> Self {
-        Self(raw)
+    /// Extra care needs to be taken that this is not a constant value or re-used within this
+    /// process in any way.
+    pub const fn from_raw(process: ProcessId, raw: NonZeroU64) -> Self {
+        Self { process, raw }
+    }
+
+    /// Creates a [`ThreadId`] for the current thread, using OS specific means to acquire it.
+    #[cfg(feature = "enable")]
+    pub(crate) fn current(process: ProcessId) -> Self {
+        #[cfg_attr(not(feature = "std"), expect(unreachable_code))]
+        Self::from_raw(process, {
+            #[cfg(feature = "std")]
+            {
+                use veecle_osal_std::thread::{Thread, ThreadAbstraction};
+                Thread::current_thread_id()
+            }
+
+            #[cfg(not(feature = "std"))]
+            {
+                panic!("not yet supported")
+            }
+        })
     }
 }
 
-impl Deref for ExecutionId {
-    type Target = u128;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-/// A telemetry message associated with a specific execution.
+/// A telemetry message associated with a specific execution thread.
 ///
 /// This structure wraps a telemetry message with its execution context,
 /// allowing messages from different executions to be properly correlated.
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(feature = "alloc", derive(Deserialize))]
 pub struct InstanceMessage<'a> {
-    /// The execution ID this message belongs to
-    pub execution: ExecutionId,
+    /// The thread this message belongs to
+    pub thread: ThreadId,
 
     /// The telemetry message content
     #[serde(borrow)]
@@ -107,7 +121,7 @@ impl ToStatic for InstanceMessage<'_> {
 
     fn to_static(&self) -> Self::Static {
         InstanceMessage {
-            execution: self.execution,
+            thread: self.thread,
             message: self.message.to_static(),
         }
     }
@@ -192,9 +206,9 @@ pub struct LogMessage<'a> {
     #[serde(borrow)]
     pub attributes: AttributeListType<'a>,
 
-    /// Optional trace ID for correlation with traces
+    /// Optional trace id for correlation with traces
     pub trace_id: Option<TraceId>,
-    /// Optional span ID for correlation with traces
+    /// Optional span id for correlation with traces
     pub span_id: Option<SpanId>,
 }
 
@@ -275,9 +289,9 @@ impl ToStatic for TracingMessage<'_> {
 pub struct SpanCreateMessage<'a> {
     /// The trace this span belongs to
     pub trace_id: TraceId,
-    /// The unique identifier for this span
+    /// The unique identifier (within the associated process) for this span.
     pub span_id: SpanId,
-    /// The parent span ID, if this is a child span
+    /// The parent span id, if this is a child span
     pub parent_span_id: Option<SpanId>,
 
     /// The name of the span
@@ -496,7 +510,7 @@ mod tests {
         let tracing_message = TracingMessage::AddEvent(span_event);
         let telemetry_message = TelemetryMessage::Tracing(tracing_message);
         let instance_message = InstanceMessage {
-            execution: ExecutionId(999),
+            thread: ThreadId::from_raw(ProcessId::from_raw(999), NonZeroU64::new(111).unwrap()),
             message: telemetry_message,
         };
 

--- a/veecle-telemetry/tests/lib.rs
+++ b/veecle-telemetry/tests/lib.rs
@@ -21,8 +21,8 @@ use veecle_telemetry::{CurrentSpan, KeyValue, Span, SpanContext, instrument, spa
 mod exporter {
     use std::sync::{Arc, LazyLock, Mutex};
 
-    use veecle_telemetry::collector::TestExporter;
-    use veecle_telemetry::protocol::{ExecutionId, InstanceMessage};
+    use veecle_telemetry::collector::{ProcessId, TestExporter};
+    use veecle_telemetry::protocol::InstanceMessage;
 
     /// Initializes the lazy lock which sets the exporter.
     pub fn set_exporter() -> ExporterHandle {
@@ -30,9 +30,8 @@ mod exporter {
             LazyLock::new(|| {
                 let (reporter, collected_spans) = TestExporter::new();
 
-                let execution_id = ExecutionId::random(&mut rand::rng());
                 veecle_telemetry::collector::set_exporter(
-                    execution_id,
+                    ProcessId::random(&mut rand::rng()),
                     Box::leak(Box::new(reporter)),
                 )
                 .expect("exporter was not set yet");


### PR DESCRIPTION
The collector is now initialized with a process id and automatically combines this with a per-thread id from the OSAL to create a globally unique id for the current thread/task.

Closes: DEV-913