### PR TITLE
fix: disable coverage collection for `std` OSAL thread test code

### DIFF
--- a/veecle-osal-std/src/lib.rs
+++ b/veecle-osal-std/src/lib.rs
@@ -3,6 +3,7 @@
 //! This provides the primitives that we need to use in Veecle OS, using the std library.
 
 #![forbid(unsafe_code)]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 pub mod log;
 pub mod net;

--- a/veecle-osal-std/src/thread.rs
+++ b/veecle-osal-std/src/thread.rs
@@ -36,6 +36,7 @@ impl ThreadAbstraction for Thread {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
Test code should not be part of the coverage data. Aligns the `std` OSAL with other crates in the repo and the contribution guidelines.