### PR TITLE
fix: decouple different ipc data channels

### DIFF
--- a/veecle-ipc/Cargo.toml
+++ b/veecle-ipc/Cargo.toml
@@ -28,6 +28,7 @@ veecle-telemetry = { workspace = true, features = ["alloc"] }
 rand = { workspace = true, features = ["std_rng"] }
 serde = { workspace = true, features = ["derive"] }
 veecle-os = { workspace = true }
+veecle-telemetry = { workspace = true, features = ["alloc", "enable"] }
 
 [lints]
 workspace = true

--- a/veecle-ipc/src/actors/output.rs
+++ b/veecle-ipc/src/actors/output.rs
@@ -52,13 +52,14 @@ pub async fn output<T>(
 where
     T: Storable<DataType: Serialize> + 'static,
 {
-    let output = config.connector.output();
+    let output = config.connector.storable_output();
     let send_policy = config.send_policy;
 
     loop {
-        let value = reader.wait_for_update().await.read(|value| {
-            veecle_ipc_protocol::Message::Storable(EncodedStorable::new(value).unwrap())
-        });
+        let value = reader
+            .wait_for_update()
+            .await
+            .read(|value| EncodedStorable::new(value).unwrap());
 
         match send_policy {
             SendPolicy::Drop => {


### PR DESCRIPTION
In some situations the ipc channels from actors to the background task can get overloaded. Currently we don't have a complete plan for how to handle this. But the major source of messages is telemetry, which is also one we can treat less reliably, so by dividing this from the data messages we can deprioritize them.

Relates to #149 