### PR TITLE
docs: add example to readme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3461,6 +3461,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "readme-example"
+version = "0.0.0"
+dependencies = [
+ "rand 0.9.2",
+ "tokio",
+ "veecle-os 0.1.0 (git+https://github.com/veecle/veecle-os?branch=main)",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4641,9 +4650,9 @@ dependencies = [
  "tokio",
  "tokio-util",
  "veecle-ipc-protocol",
- "veecle-os",
- "veecle-os-runtime",
- "veecle-telemetry",
+ "veecle-os 0.1.0",
+ "veecle-os-runtime 0.1.0",
+ "veecle-telemetry 0.1.0",
 ]
 
 [[package]]
@@ -4656,8 +4665,8 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio-util",
  "uuid",
- "veecle-os-runtime",
- "veecle-telemetry",
+ "veecle-os-runtime 0.1.0",
+ "veecle-telemetry 0.1.0",
 ]
 
 [[package]]
@@ -4696,7 +4705,7 @@ dependencies = [
  "veecle-ipc-protocol",
  "veecle-net-utils",
  "veecle-orchestrator-protocol",
- "veecle-telemetry",
+ "veecle-telemetry 0.1.0",
 ]
 
 [[package]]
@@ -4730,12 +4739,23 @@ version = "0.1.0"
 dependencies = [
  "veecle-os-data-support-can",
  "veecle-os-data-support-someip",
- "veecle-os-runtime",
- "veecle-osal-api",
+ "veecle-os-runtime 0.1.0",
+ "veecle-osal-api 0.1.0",
  "veecle-osal-embassy",
  "veecle-osal-freertos",
- "veecle-osal-std",
- "veecle-telemetry",
+ "veecle-osal-std 0.1.0",
+ "veecle-telemetry 0.1.0",
+]
+
+[[package]]
+name = "veecle-os"
+version = "0.1.0"
+source = "git+https://github.com/veecle/veecle-os?branch=main#89a88dd5945752995aa3e14f636245945cff0d40"
+dependencies = [
+ "veecle-os-runtime 0.1.0 (git+https://github.com/veecle/veecle-os?branch=main)",
+ "veecle-osal-api 0.1.0 (git+https://github.com/veecle/veecle-os?branch=main)",
+ "veecle-osal-std 0.1.0 (git+https://github.com/veecle/veecle-os?branch=main)",
+ "veecle-telemetry 0.1.0 (git+https://github.com/veecle/veecle-os?branch=main)",
 ]
 
 [[package]]
@@ -4753,7 +4773,7 @@ dependencies = [
  "tinyvec",
  "veecle-os-data-support-can-codegen",
  "veecle-os-data-support-can-macros",
- "veecle-os-runtime",
+ "veecle-os-runtime 0.1.0",
 ]
 
 [[package]]
@@ -4774,7 +4794,7 @@ dependencies = [
  "syn 2.0.110",
  "unicode-ident",
  "veecle-os-data-support-can",
- "veecle-os-runtime",
+ "veecle-os-runtime 0.1.0",
 ]
 
 [[package]]
@@ -4822,11 +4842,26 @@ dependencies = [
  "tokio",
  "trybuild",
  "typenum",
- "veecle-os-runtime-macros",
+ "veecle-os-runtime-macros 0.1.0",
  "veecle-os-test",
- "veecle-telemetry",
+ "veecle-telemetry 0.1.0",
  "wakerset",
  "walkdir",
+]
+
+[[package]]
+name = "veecle-os-runtime"
+version = "0.1.0"
+source = "git+https://github.com/veecle/veecle-os?branch=main#89a88dd5945752995aa3e14f636245945cff0d40"
+dependencies = [
+ "futures",
+ "generic-array 1.3.5",
+ "pin-cell",
+ "pin-project",
+ "typenum",
+ "veecle-os-runtime-macros 0.1.0 (git+https://github.com/veecle/veecle-os?branch=main)",
+ "veecle-telemetry 0.1.0 (git+https://github.com/veecle/veecle-os?branch=main)",
+ "wakerset",
 ]
 
 [[package]]
@@ -4841,8 +4876,21 @@ dependencies = [
  "runtime-macros",
  "syn 2.0.110",
  "trybuild",
- "veecle-os-runtime",
+ "veecle-os-runtime 0.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "veecle-os-runtime-macros"
+version = "0.1.0"
+source = "git+https://github.com/veecle/veecle-os?branch=main#89a88dd5945752995aa3e14f636245945cff0d40"
+dependencies = [
+ "darling 0.21.3",
+ "heck",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4850,8 +4898,8 @@ name = "veecle-os-test"
 version = "0.1.0"
 dependencies = [
  "futures",
- "veecle-os",
- "veecle-os-runtime",
+ "veecle-os 0.1.0",
+ "veecle-os-runtime 0.1.0",
 ]
 
 [[package]]
@@ -4863,9 +4911,19 @@ dependencies = [
  "serde",
  "tokio",
  "trybuild",
- "veecle-os-runtime",
- "veecle-osal-std",
+ "veecle-os-runtime 0.1.0",
+ "veecle-osal-std 0.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "veecle-osal-api"
+version = "0.1.0"
+source = "git+https://github.com/veecle/veecle-os?branch=main#89a88dd5945752995aa3e14f636245945cff0d40"
+dependencies = [
+ "embedded-io-async",
+ "futures",
+ "serde",
 ]
 
 [[package]]
@@ -4884,7 +4942,7 @@ dependencies = [
  "heapless",
  "rtt-target",
  "static_cell",
- "veecle-osal-api",
+ "veecle-osal-api 0.1.0",
 ]
 
 [[package]]
@@ -4895,7 +4953,7 @@ dependencies = [
  "rtt-target",
  "veecle-freertos-integration",
  "veecle-freertos-sys",
- "veecle-osal-api",
+ "veecle-osal-api 0.1.0",
 ]
 
 [[package]]
@@ -4909,8 +4967,24 @@ dependencies = [
  "rand 0.9.2",
  "socket2",
  "tokio",
- "veecle-osal-api",
- "veecle-osal-std-macros",
+ "veecle-osal-api 0.1.0",
+ "veecle-osal-std-macros 0.1.0",
+]
+
+[[package]]
+name = "veecle-osal-std"
+version = "0.1.0"
+source = "git+https://github.com/veecle/veecle-os?branch=main#89a88dd5945752995aa3e14f636245945cff0d40"
+dependencies = [
+ "embedded-io",
+ "embedded-io-adapters",
+ "embedded-io-async",
+ "futures",
+ "rand 0.9.2",
+ "socket2",
+ "tokio",
+ "veecle-osal-api 0.1.0 (git+https://github.com/veecle/veecle-os?branch=main)",
+ "veecle-osal-std-macros 0.1.0 (git+https://github.com/veecle/veecle-os?branch=main)",
 ]
 
 [[package]]
@@ -4924,9 +4998,21 @@ dependencies = [
  "runtime-macros",
  "syn 2.0.110",
  "trybuild",
- "veecle-os",
- "veecle-telemetry",
+ "veecle-os 0.1.0",
+ "veecle-telemetry 0.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "veecle-osal-std-macros"
+version = "0.1.0"
+source = "git+https://github.com/veecle/veecle-os?branch=main#89a88dd5945752995aa3e14f636245945cff0d40"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4943,9 +5029,23 @@ dependencies = [
  "serial_test",
  "tokio",
  "veecle-osal-freertos",
- "veecle-osal-std",
- "veecle-telemetry",
- "veecle-telemetry-macros",
+ "veecle-osal-std 0.1.0",
+ "veecle-telemetry 0.1.0",
+ "veecle-telemetry-macros 0.1.0",
+]
+
+[[package]]
+name = "veecle-telemetry"
+version = "0.1.0"
+source = "git+https://github.com/veecle/veecle-os?branch=main#89a88dd5945752995aa3e14f636245945cff0d40"
+dependencies = [
+ "hex",
+ "pin-project",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "veecle-osal-std 0.1.0 (git+https://github.com/veecle/veecle-os?branch=main)",
+ "veecle-telemetry-macros 0.1.0 (git+https://github.com/veecle/veecle-os?branch=main)",
 ]
 
 [[package]]
@@ -4956,7 +5056,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
- "veecle-telemetry",
+ "veecle-telemetry 0.1.0",
+]
+
+[[package]]
+name = "veecle-telemetry-macros"
+version = "0.1.0"
+source = "git+https://github.com/veecle/veecle-os?branch=main#89a88dd5945752995aa3e14f636245945cff0d40"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4971,7 +5082,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-tungstenite",
- "veecle-telemetry",
+ "veecle-telemetry 0.1.0",
  "veecle-telemetry-server-protocol",
 ]
 
@@ -5004,9 +5115,9 @@ dependencies = [
  "rfd",
  "serde",
  "serde_json",
- "veecle-os-runtime",
- "veecle-osal-std",
- "veecle-telemetry",
+ "veecle-os-runtime 0.1.0",
+ "veecle-osal-std 0.1.0",
+ "veecle-telemetry 0.1.0",
  "veecle-telemetry-server-protocol",
  "wasm-bindgen-futures",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
   "capicxx-someip-sys",
   "docs/generate-markdown-index",
+  "readme-example",
   "someip-test-service",
   "someip-test-service-macro",
   "someip-test-service-sys",

--- a/readme-example/Cargo.toml
+++ b/readme-example/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "readme-example"
+edition.workspace = true
+rust-version.workspace = true
+description.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
+
+[dev-dependencies]
+# Must be kept in sync with the root README.md.
+rand = "0.9.2"
+tokio = "1.48.0"
+# TODO(#161): Use released version when `ConsolePrettyExporter` is released.
+veecle-os = { git = "https://github.com/veecle/veecle-os", branch = "main", features = [
+  "osal-std",
+  "telemetry-enable",
+] }
+
+[lints]
+workspace = true

--- a/readme-example/src/lib.rs
+++ b/readme-example/src/lib.rs
@@ -1,0 +1,3 @@
+// Include the root readme to test the example in CI.
+// Can be manually checked with `cargo test --doc -p readme-example`.
+#![doc = include_str!("../../README.md")]


### PR DESCRIPTION
The example showcases target agnostic actors leveraging the OSAL. Logs are printed via the pretty print exporter.
Uses a git dependency to be able to use the pretty print exporter. The `readme-example` crate checks the readme example in CI.

Fixes the license link in the readme to use the existing reference.

Fixes: DEV-1176