### PR TITLE
refactor(telemetry)!: replace `TraceId` with `ProcessId` for span identification

### DIFF
--- a/veecle-ipc/src/telemetry.rs
+++ b/veecle-ipc/src/telemetry.rs
@@ -33,11 +33,11 @@ impl Export for Exporter {
 mod tests {
     use core::num::NonZeroU64;
     use tokio::sync::mpsc;
+    use veecle_telemetry::SpanId;
     use veecle_telemetry::collector::Export;
     use veecle_telemetry::protocol::{
         InstanceMessage, LogMessage, ProcessId, Severity, TelemetryMessage, ThreadId,
     };
-    use veecle_telemetry::{SpanId, TraceId};
 
     use super::Exporter;
 
@@ -56,7 +56,6 @@ mod tests {
                 severity: Severity::Info,
                 body: "test log message".into(),
                 attributes: Default::default(),
-                trace_id: Some(TraceId(0x1234)),
                 span_id: Some(SpanId(0x5678)),
             }),
         };
@@ -72,7 +71,6 @@ mod tests {
                         assert_eq!(message.time_unix_nano, 1000000000);
                         assert_eq!(message.severity, Severity::Info);
                         assert_eq!(message.body.as_ref(), "test log message");
-                        assert_eq!(message.trace_id, Some(TraceId(0x1234)));
                         assert_eq!(message.span_id, Some(SpanId(0x5678)));
                     }
                     _ => panic!("Expected Log message"),
@@ -96,7 +94,6 @@ mod tests {
                 severity: Severity::Error,
                 body: "error log message".into(),
                 attributes: Default::default(),
-                trace_id: Some(TraceId(0xabcd)),
                 span_id: Some(SpanId(0xef01)),
             }),
         };

--- a/veecle-telemetry/src/id.rs
+++ b/veecle-telemetry/src/id.rs
@@ -10,18 +10,13 @@
 //!
 //! # Core Types
 //!
-//! - [`TraceId`]: A 128-bit globally unique identifier that groups related spans together
-//! - [`SpanId`]: A 64-bit identifier that uniquely identifies a span within a trace
-//! - [`SpanContext`]: A combination of trace ID and span ID that uniquely identifies a span
+//! - [`SpanId`]: An identifier that uniquely identifies a span within a process.
+//! - [`SpanContext`]: A combination of process id and span id that uniquely identifies a span globally.
 
 use core::fmt;
 use core::str::FromStr;
 
 use serde::{Deserialize, Serialize};
-
-use crate::collector::get_collector;
-#[cfg(feature = "enable")]
-use crate::span::CURRENT_SPAN;
 
 /// A globally-unique id identifying a process.
 ///
@@ -57,58 +52,7 @@ impl ProcessId {
     }
 }
 
-/// An identifier for a trace, which groups a set of related spans together.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct TraceId(pub u128);
-
-impl TraceId {
-    /// Uses the state in the collector to generate a `TraceId`.
-    ///
-    /// Returns 0 if the collector has not been initialized via [`crate::collector::set_exporter`].
-    #[inline]
-    pub fn generate() -> Self {
-        get_collector().generate_trace_id()
-    }
-}
-
-impl fmt::Display for TraceId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:032x}", self.0)
-    }
-}
-
-impl FromStr for TraceId {
-    type Err = core::num::ParseIntError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        u128::from_str_radix(s, 16).map(TraceId)
-    }
-}
-
-impl serde::Serialize for TraceId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut hex_bytes = [0u8; size_of::<u128>() * 2];
-        hex::encode_to_slice(self.0.to_le_bytes(), &mut hex_bytes).unwrap();
-
-        serializer.serialize_str(str::from_utf8(&hex_bytes).unwrap())
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for TraceId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let bytes: [u8; size_of::<u128>()] = hex::serde::deserialize(deserializer)?;
-
-        Ok(TraceId(u128::from_le_bytes(bytes)))
-    }
-}
-
-/// An identifier for a span within a trace.
+/// A process-unique id for a span.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct SpanId(pub u64);
 
@@ -116,35 +60,11 @@ pub struct SpanId(pub u64);
 impl SpanId {
     #[inline]
     #[doc(hidden)]
-    /// Creates a non-zero `SpanId`
-    pub fn next_id() -> SpanId {
-        #[cfg(feature = "std")]
-        {
-            std::thread_local! {
-                static LOCAL_ID_GENERATOR: core::cell::Cell<u64> = core::cell::Cell::new(rand::random::<u64>() & 0xffffffff00000000);
-            }
-
-            LOCAL_ID_GENERATOR
-                .try_with(|g| {
-                    let id = g.get().wrapping_add(1);
-                    g.set(id);
-
-                    SpanId(id)
-                })
-                .unwrap_or({
-                    // This only gets called if the TLS key has been destroyed, it should be safe to fall back to a 0
-                    // value (noop) `SpanId`
-                    SpanId(0)
-                })
-        }
-
-        #[cfg(not(feature = "std"))]
-        {
-            use core::sync::atomic;
-            // For no_std, use a simple counter approach
-            static COUNTER: atomic::AtomicU64 = atomic::AtomicU64::new(1);
-            SpanId(COUNTER.fetch_add(1, atomic::Ordering::Relaxed))
-        }
+    /// Creates a non-zero [`SpanId`].
+    pub fn next_id() -> Self {
+        use core::sync::atomic;
+        static COUNTER: atomic::AtomicU64 = atomic::AtomicU64::new(1);
+        SpanId(COUNTER.fetch_add(1, atomic::Ordering::Relaxed))
     }
 }
 
@@ -185,50 +105,29 @@ impl<'de> serde::Deserialize<'de> for SpanId {
     }
 }
 
-/// A struct representing the context of a span, including its [`TraceId`] and [`SpanId`].
-///
-/// [`TraceId`]: crate::id::TraceId
-/// [`SpanId`]: crate::id::SpanId
+/// A struct representing the context of a span, including its [`ProcessId`] and [`SpanId`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct SpanContext {
-    /// The trace ID this span belongs to
-    pub trace_id: TraceId,
-    /// The unique ID of this span
+    /// The id of the process this span belongs to.
+    pub process_id: ProcessId,
+    /// The unique id of this span.
     pub span_id: SpanId,
 }
 
 impl SpanContext {
-    /// Creates a new `SpanContext` with the given [`TraceId`] and [`SpanId`].
+    /// Creates a new `SpanContext` with the given [`ProcessId`] and [`SpanId`].
     ///
     /// # Examples
     ///
     /// ```
-    /// use veecle_telemetry::id::*;
+    /// use veecle_telemetry::{ProcessId, SpanId, SpanContext};
     ///
-    /// let span_context = SpanContext::new(TraceId(12), SpanId(13));
+    /// let span_context = SpanContext::new(ProcessId::from_raw(12), SpanId(13));
     /// ```
-    ///
-    /// [`TraceId`]: crate::id::TraceId
-    /// [`SpanId`]: crate::id::SpanId
-    pub fn new(trace_id: TraceId, span_id: SpanId) -> Self {
-        Self { trace_id, span_id }
-    }
-
-    /// Creates a new `SpanContext` with a `TraceId` generated with the state in the collector.
-    ///
-    /// Returns 0 if the collector has not been initialized via [`crate::collector::set_exporter`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use veecle_telemetry::*;
-    ///
-    /// let random = SpanContext::generate();
-    /// ```
-    pub fn generate() -> Self {
+    pub fn new(process_id: ProcessId, span_id: SpanId) -> Self {
         Self {
-            trace_id: TraceId::generate(),
-            span_id: SpanId(0),
+            process_id,
+            span_id,
         }
     }
 
@@ -254,7 +153,9 @@ impl SpanContext {
 
         #[cfg(feature = "enable")]
         {
-            CURRENT_SPAN.get()
+            crate::span::CURRENT_SPAN
+                .get()
+                .map(|span_id| Self::new(crate::collector::get_collector().process_id(), span_id))
         }
     }
 }
@@ -291,26 +192,6 @@ mod tests {
     }
 
     #[test]
-    fn trace_id_formatting() {
-        assert_eq!(
-            format!("{}", TraceId(0)),
-            "00000000000000000000000000000000"
-        );
-        assert_eq!(
-            format!("{}", TraceId(u128::MAX)),
-            "ffffffffffffffffffffffffffffffff"
-        );
-        assert_eq!(
-            format!("{}", TraceId(0x123456789ABCDEF0FEDCBA9876543210)),
-            "123456789abcdef0fedcba9876543210"
-        );
-        assert_eq!(
-            format!("{}", TraceId(0x123)),
-            "00000000000000000000000000000123"
-        );
-    }
-
-    #[test]
     fn span_id_formatting() {
         assert_eq!(format!("{}", SpanId(0)), "0000000000000000");
         assert_eq!(format!("{}", SpanId(u64::MAX)), "ffffffffffffffff");
@@ -319,39 +200,6 @@ mod tests {
             "fedcba9876543210"
         );
         assert_eq!(format!("{}", SpanId(0x123)), "0000000000000123");
-    }
-
-    #[test]
-    fn trace_id_from_str() {
-        assert_eq!(
-            "123456789abcdef0fedcba9876543210"
-                .parse::<TraceId>()
-                .unwrap(),
-            TraceId(0x123456789ABCDEF0FEDCBA9876543210)
-        );
-        assert_eq!(
-            "123456789ABCDEF0FEDCBA9876543210"
-                .parse::<TraceId>()
-                .unwrap(),
-            TraceId(0x123456789ABCDEF0FEDCBA9876543210)
-        );
-        assert_eq!(
-            "00000000000000000000000000000000"
-                .parse::<TraceId>()
-                .unwrap(),
-            TraceId(0)
-        );
-        assert_eq!(
-            "ffffffffffffffffffffffffffffffff"
-                .parse::<TraceId>()
-                .unwrap(),
-            TraceId(u128::MAX)
-        );
-        // Shorter hex string works as u128::from_str_radix handles it
-        assert_eq!("123".parse::<TraceId>().unwrap(), TraceId(0x123));
-
-        assert!("xyz".parse::<TraceId>().is_err());
-        assert!("".parse::<TraceId>().is_err());
     }
 
     #[test]
@@ -376,25 +224,6 @@ mod tests {
     }
 
     #[test]
-    fn trace_id_format_from_str_roundtrip() {
-        let test_cases = [
-            0u128,
-            1,
-            0x123,
-            0x123456789ABCDEF0FEDCBA9876543210,
-            u128::MAX,
-            u128::MAX - 1,
-        ];
-
-        for value in test_cases {
-            let trace_id = TraceId(value);
-            let formatted = format!("{trace_id}");
-            let parsed = formatted.parse::<TraceId>().unwrap();
-            assert_eq!(trace_id, parsed, "Failed roundtrip for value {value:#x}");
-        }
-    }
-
-    #[test]
     fn span_id_format_from_str_roundtrip() {
         let test_cases = [0u64, 1, 0x123, 0xFEDCBA9876543210, u64::MAX, u64::MAX - 1];
 
@@ -403,28 +232,6 @@ mod tests {
             let formatted = format!("{span_id}");
             let parsed = formatted.parse::<SpanId>().unwrap();
             assert_eq!(span_id, parsed, "Failed roundtrip for value {value:#x}");
-        }
-    }
-
-    #[test]
-    fn trace_id_serde_roundtrip() {
-        let test_cases = [
-            TraceId(0),
-            TraceId(1),
-            TraceId(0x123),
-            TraceId(0x123456789ABCDEF0FEDCBA9876543210),
-            TraceId(u128::MAX),
-            TraceId(u128::MAX - 1),
-        ];
-
-        for original in test_cases {
-            let json = serde_json::to_string(&original).unwrap();
-            let deserialized: TraceId = serde_json::from_str(&json).unwrap();
-            assert_eq!(
-                original, deserialized,
-                "JSON roundtrip failed for {:#x}",
-                original.0
-            );
         }
     }
 
@@ -453,43 +260,27 @@ mod tests {
     #[test]
     fn span_context_serde_roundtrip() {
         let test_cases = [
-            SpanContext::new(TraceId(0), SpanId(0)),
+            SpanContext::new(ProcessId::from_raw(0), SpanId(0)),
             SpanContext::new(
-                TraceId(0x123456789ABCDEF0FEDCBA9876543210),
+                ProcessId::from_raw(0x123456789ABCDEF0FEDCBA9876543210),
                 SpanId(0xFEDCBA9876543210),
             ),
-            SpanContext::new(TraceId(u128::MAX), SpanId(u64::MAX)),
-            SpanContext::new(TraceId(1), SpanId(1)),
+            SpanContext::new(ProcessId::from_raw(u128::MAX), SpanId(u64::MAX)),
+            SpanContext::new(ProcessId::from_raw(1), SpanId(1)),
         ];
 
         for original in test_cases {
             let json = serde_json::to_string(&original).unwrap();
             let deserialized: SpanContext = serde_json::from_str(&json).unwrap();
             assert_eq!(
-                original.trace_id, deserialized.trace_id,
-                "JSON roundtrip failed for trace_id"
+                original.process_id, deserialized.process_id,
+                "JSON roundtrip failed for process_id"
             );
             assert_eq!(
                 original.span_id, deserialized.span_id,
                 "JSON roundtrip failed for span_id"
             );
         }
-    }
-
-    #[test]
-    fn trace_id_serialization_format() {
-        let trace_id = TraceId(0x123456789ABCDEF0FEDCBA9876543210);
-        let json = serde_json::to_string(&trace_id).unwrap();
-
-        // Serialization uses little-endian bytes
-        let expected_le_bytes = 0x123456789ABCDEF0FEDCBA9876543210u128.to_le_bytes();
-        let mut expected_hex = String::new();
-        for byte in &expected_le_bytes {
-            expected_hex.push_str(&format!("{byte:02x}"));
-        }
-        let expected_json = format!("\"{expected_hex}\"");
-
-        assert_eq!(json, expected_json);
     }
 
     #[test]
@@ -509,20 +300,12 @@ mod tests {
 
     #[test]
     fn span_context_new_and_fields() {
-        let trace_id = TraceId(0x123);
+        let process_id = ProcessId::from_raw(0x123);
         let span_id = SpanId(0x456);
-        let context = SpanContext::new(trace_id, span_id);
+        let context = SpanContext::new(process_id, span_id);
 
-        assert_eq!(context.trace_id, trace_id);
+        assert_eq!(context.process_id, process_id);
         assert_eq!(context.span_id, span_id);
-    }
-
-    #[test]
-    fn span_context_generate_produces_non_zero_trace_id() {
-        let context = SpanContext::generate();
-        // span_id should be 0 as per the implementation
-        assert_eq!(context.span_id, SpanId(0));
-        // trace_id value depends on collector initialization
     }
 
     #[test]

--- a/veecle-telemetry/src/lib.rs
+++ b/veecle-telemetry/src/lib.rs
@@ -111,7 +111,7 @@ pub mod to_static;
 pub mod types;
 pub mod value;
 
-pub use id::{ProcessId, SpanContext, SpanId, TraceId};
+pub use id::{ProcessId, SpanContext, SpanId};
 pub use span::{CurrentSpan, Span, SpanGuard, SpanGuardRef};
 pub use value::{KeyValue, Value};
 pub use veecle_telemetry_macros::instrument;

--- a/veecle-telemetry/src/log.rs
+++ b/veecle-telemetry/src/log.rs
@@ -25,8 +25,6 @@
 
 use crate::KeyValue;
 #[cfg(feature = "enable")]
-use crate::SpanContext;
-#[cfg(feature = "enable")]
 use crate::collector::get_collector;
 use crate::protocol::Severity;
 #[cfg(feature = "enable")]
@@ -84,19 +82,13 @@ pub fn log(severity: Severity, body: &'static str, attributes: &'_ [KeyValue<'st
 
     #[cfg(feature = "enable")]
     {
-        let current_context = SpanContext::current();
-        let (trace_id, span_id) = if let Some(context) = current_context {
-            (Some(context.trace_id), Some(context.span_id))
-        } else {
-            (None, None)
-        };
+        let span_id = crate::SpanContext::current().map(|context| context.span_id);
 
         let log_message = LogMessage {
             time_unix_nano: now().as_nanos(),
             severity,
             body: body.into(),
             attributes: attribute_list_from_slice(attributes),
-            trace_id,
             span_id,
         };
 

--- a/veecle-telemetry/src/macros.rs
+++ b/veecle-telemetry/src/macros.rs
@@ -347,7 +347,7 @@ macro_rules! fatal {
 ///
 /// Span construction with attributes:
 /// ```rust
-/// use veecle_telemetry::{Span, SpanContext, attributes};
+/// use veecle_telemetry::{Span, attributes};
 ///
 /// let operation = "user_login";
 /// let user_id = 456;

--- a/veecle-telemetry/tests/lib.rs
+++ b/veecle-telemetry/tests/lib.rs
@@ -238,7 +238,7 @@ fn span_property() {
 #[test]
 #[serial]
 fn current_span_integration() {
-    use veecle_telemetry::{CurrentSpan, SpanId, TraceId};
+    use veecle_telemetry::{CurrentSpan, ProcessId, SpanId};
 
     let exporter = set_exporter();
 
@@ -257,8 +257,10 @@ fn current_span_integration() {
         );
 
         // Test CurrentSpan::link
-        let external_context =
-            SpanContext::new(TraceId(0x123456789ABCDEF0), SpanId(0xFEDCBA9876543210));
+        let external_context = SpanContext::new(
+            ProcessId::from_raw(0x123456789ABCDEF0),
+            SpanId(0xFEDCBA9876543210),
+        );
         CurrentSpan::add_link(external_context);
 
         // Test CurrentSpan::attribute
@@ -275,8 +277,10 @@ fn current_span_integration() {
         );
         CurrentSpan::set_attribute(KeyValue::new("child_runtime_attr", 100));
 
-        let another_external =
-            SpanContext::new(TraceId(0x1111111111111111), SpanId(0x2222222222222222));
+        let another_external = SpanContext::new(
+            ProcessId::from_raw(0x1111111111111111),
+            SpanId(0x2222222222222222),
+        );
         CurrentSpan::add_link(another_external);
     }
 
@@ -286,11 +290,11 @@ fn current_span_integration() {
         indoc! {r#"
             root []
                 + attr: runtime_attr="added_later"
-                + link: trace=123456789abcdef0, span=fedcba9876543210
+                + link: process=123456789abcdef0 span=fedcba9876543210
                 + event: test_event [event_key="event_value", event_num=42]
                 child [child_attr=true]
                     + attr: child_runtime_attr=100
-                    + link: trace=1111111111111111, span=2222222222222222
+                    + link: process=1111111111111111 span=2222222222222222
                     + event: child_event [child_event_data="nested"]
         "#}
     );


### PR DESCRIPTION
Remove the `TraceId` concept and use `ProcessId` directly to identify the context within which `SpanId`s are unique.

Previously, `TraceId` was generated from `ProcessId` using a counter, but this added complexity without clear benefit and requires thread local state. `SpanId`s are now unique within a process, and the combination of `ProcessId` + `SpanId` provides global uniqueness through `SpanContext`.