### PR TITLE
refactor(telemetry): remove thread-local current span tracking

### DIFF
--- a/veecle-ipc/src/telemetry.rs
+++ b/veecle-ipc/src/telemetry.rs
@@ -33,7 +33,6 @@ impl Export for Exporter {
 mod tests {
     use core::num::NonZeroU64;
     use tokio::sync::mpsc;
-    use veecle_telemetry::SpanId;
     use veecle_telemetry::collector::Export;
     use veecle_telemetry::protocol::{
         InstanceMessage, LogMessage, ProcessId, Severity, TelemetryMessage, ThreadId,
@@ -56,7 +55,6 @@ mod tests {
                 severity: Severity::Info,
                 body: "test log message".into(),
                 attributes: Default::default(),
-                span_id: Some(SpanId(0x5678)),
             }),
         };
 
@@ -71,7 +69,6 @@ mod tests {
                         assert_eq!(message.time_unix_nano, 1000000000);
                         assert_eq!(message.severity, Severity::Info);
                         assert_eq!(message.body.as_ref(), "test log message");
-                        assert_eq!(message.span_id, Some(SpanId(0x5678)));
                     }
                     _ => panic!("Expected Log message"),
                 }
@@ -94,7 +91,6 @@ mod tests {
                 severity: Severity::Error,
                 body: "error log message".into(),
                 attributes: Default::default(),
-                span_id: Some(SpanId(0xef01)),
             }),
         };
 

--- a/veecle-telemetry-ui/src/store/mod.rs
+++ b/veecle-telemetry-ui/src/store/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! See [`Store`].
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Formatter;
 use std::ops::{Add, Deref, Sub};
 #[cfg(not(target_arch = "wasm32"))]
@@ -44,6 +44,10 @@ pub struct Store {
     logs: Vec<Log>,
     actors: HashSet<String>,
 
+    /// Tracks the currently entered spans for a specific thread of execution to mark the parent of
+    /// newly created spans.
+    execution_contexts: HashMap<ThreadId, Vec<SpanContext>>,
+
     /// The earliest known timestamp.
     ///
     /// Gets initialized to [`Timestamp::MAX`] so the first real timestamp becomes the start.
@@ -70,6 +74,7 @@ impl Default for Store {
             root_spans: IndexSet::default(),
             logs: Vec::default(),
             actors: HashSet::default(),
+            execution_contexts: HashMap::default(),
             start: Timestamp::MAX,
             end: Timestamp::MIN,
             last_update: Instant::now(),
@@ -205,6 +210,11 @@ impl Store {
         timestamp
     }
 
+    /// Returns the span at the top of the stack for `thread_id`.
+    fn current_span_for(&self, thread_id: ThreadId) -> Option<SpanContext> {
+        self.execution_contexts.get(&thread_id)?.last().copied()
+    }
+
     /// Processes a single tracing message.
     fn process_tracing_message(&mut self, thread_id: ThreadId, tracing_msg: TracingMessage) {
         match tracing_msg {
@@ -212,9 +222,7 @@ impl Store {
                 let timestamp = self.update_timestamp(span_msg.start_time_unix_nano);
 
                 let context = SpanContext::new(thread_id.process, span_msg.span_id);
-                let parent_context = span_msg
-                    .parent_span_id
-                    .map(|parent_id| SpanContext::new(thread_id.process, parent_id));
+                let parent_context = self.current_span_for(thread_id);
 
                 let mut parent_span = parent_context.map(|parent| {
                     self.spans
@@ -260,6 +268,10 @@ impl Store {
                 let timestamp = self.update_timestamp(enter_msg.time_unix_nano);
 
                 let span_context = SpanContext::new(thread_id.process, enter_msg.span_id);
+                self.execution_contexts
+                    .entry(thread_id)
+                    .or_default()
+                    .push(span_context);
 
                 let span = self
                     .spans
@@ -276,6 +288,12 @@ impl Store {
                 let timestamp = self.update_timestamp(exit_msg.time_unix_nano);
 
                 let span_context = SpanContext::new(thread_id.process, exit_msg.span_id);
+                let expected = self.execution_contexts.entry(thread_id).or_default().pop();
+                if expected != Some(span_context) {
+                    log::warn!(
+                        "execution exited span that wasn't at the top of its stack: expected={expected:?} got={span_context:?}"
+                    );
+                }
                 let span = self
                     .spans
                     .get_mut(&span_context)
@@ -315,7 +333,23 @@ impl Store {
             TracingMessage::AddEvent(event_msg) => {
                 let timestamp = self.update_timestamp(event_msg.time_unix_nano);
 
-                let span_context = SpanContext::new(thread_id.process, event_msg.span_id);
+                let Some(span_context) = event_msg
+                    .span_id
+                    .map(|span_id| SpanContext::new(thread_id.process, span_id))
+                    .or_else(|| {
+                        self.execution_contexts
+                            .entry(thread_id)
+                            .or_default()
+                            .last()
+                            .cloned()
+                    })
+                else {
+                    log::warn!(
+                        "received AddEvent for current span but no current span known for {thread_id:?}"
+                    );
+                    return;
+                };
+
                 let span = self
                     .spans
                     .get_mut(&span_context)
@@ -351,7 +385,17 @@ impl Store {
                 });
             }
             TracingMessage::AddLink(link_msg) => {
-                let span_context = SpanContext::new(thread_id.process, link_msg.span_id);
+                let Some(span_context) = link_msg
+                    .span_id
+                    .map(|span_id| SpanContext::new(thread_id.process, span_id))
+                    .or_else(|| self.current_span_for(thread_id))
+                else {
+                    log::warn!(
+                        "received AddLink for current span but no current span known for {thread_id:?}"
+                    );
+                    return;
+                };
+
                 let linked_span_context = link_msg.link;
 
                 let span = self
@@ -361,7 +405,18 @@ impl Store {
                 span.links.push(linked_span_context);
             }
             TracingMessage::SetAttribute(attr_msg) => {
-                let span_context = SpanContext::new(thread_id.process, attr_msg.span_id);
+                let Some(span_context) = attr_msg
+                    .span_id
+                    .map(|span_id| SpanContext::new(thread_id.process, span_id))
+                    .or_else(|| self.current_span_for(thread_id))
+                else {
+                    log::warn!(
+                        "received SetAttribute for current span but no current span known for
+                        {thread_id:?}"
+                    );
+                    return;
+                };
+
                 let span = self
                     .spans
                     .get_mut(&span_context)
@@ -383,9 +438,8 @@ impl Store {
         let timestamp = self.update_timestamp(log_msg.time_unix_nano);
 
         // Find the span this log belongs to, or use the program span.
-        let span_context = log_msg
-            .span_id
-            .map(|span_id| SpanContext::new(thread_id.process, span_id))
+        let span_context = self
+            .current_span_for(thread_id)
             .unwrap_or(PROGRAM_SPAN_CONTEXT);
 
         let span = if let Some(span) = self.spans.get_mut(&span_context) {

--- a/veecle-telemetry/src/id.rs
+++ b/veecle-telemetry/src/id.rs
@@ -163,34 +163,6 @@ impl SpanContext {
             span_id,
         }
     }
-
-    /// Creates a `SpanContext` from the current local parent span. If there is no
-    /// local parent span, this function will return `None`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use veecle_telemetry::*;
-    ///
-    /// let span = Span::new("root", &[]);
-    /// let _guard = span.entered();
-    ///
-    /// let span_context = SpanContext::current();
-    /// assert!(span_context.is_some());
-    /// ```
-    pub fn current() -> Option<Self> {
-        #[cfg(not(feature = "enable"))]
-        {
-            None
-        }
-
-        #[cfg(feature = "enable")]
-        {
-            crate::span::CURRENT_SPAN
-                .get()
-                .map(|span_id| Self::new(crate::collector::get_collector().process_id(), span_id))
-        }
-    }
 }
 
 impl fmt::Display for SpanContext {

--- a/veecle-telemetry/src/log.rs
+++ b/veecle-telemetry/src/log.rs
@@ -82,14 +82,11 @@ pub fn log(severity: Severity, body: &'static str, attributes: &'_ [KeyValue<'st
 
     #[cfg(feature = "enable")]
     {
-        let span_id = crate::SpanContext::current().map(|context| context.span_id);
-
         let log_message = LogMessage {
             time_unix_nano: now().as_nanos(),
             severity,
             body: body.into(),
             attributes: attribute_list_from_slice(attributes),
-            span_id,
         };
 
         get_collector().log_message(log_message);

--- a/veecle-telemetry/src/protocol.rs
+++ b/veecle-telemetry/src/protocol.rs
@@ -321,8 +321,6 @@ pub struct LogMessage<'a> {
     /// Key-value attributes providing additional context
     #[serde(borrow)]
     pub attributes: AttributeListType<'a>,
-    /// Optional span id for correlation with traces
-    pub span_id: Option<SpanId>,
 }
 
 #[cfg(feature = "alloc")]
@@ -335,7 +333,6 @@ impl ToStatic for LogMessage<'_> {
             severity: self.severity,
             body: self.body.to_static(),
             attributes: self.attributes.to_static(),
-            span_id: self.span_id,
         }
     }
 }
@@ -401,8 +398,6 @@ impl ToStatic for TracingMessage<'_> {
 pub struct SpanCreateMessage<'a> {
     /// The unique identifier (within the associated process) for this span.
     pub span_id: SpanId,
-    /// The parent span id, if this is a child span
-    pub parent_span_id: Option<SpanId>,
 
     /// The name of the span
     #[serde(borrow)]
@@ -423,7 +418,6 @@ impl ToStatic for SpanCreateMessage<'_> {
     fn to_static(&self) -> Self::Static {
         SpanCreateMessage {
             span_id: self.span_id,
-            parent_span_id: self.parent_span_id,
             name: self.name.to_static(),
             start_time_unix_nano: self.start_time_unix_nano,
             attributes: self.attributes.to_static(),
@@ -464,8 +458,9 @@ pub struct SpanCloseMessage {
 /// Message indicating an attribute has been set on a span.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SpanSetAttributeMessage<'a> {
-    /// The span the attribute is being set on
-    pub span_id: SpanId,
+    /// The span the attribute is being set on, if [`None`] then this applies to the "current span"
+    /// as determined by tracking [`SpanEnterMessage`] and [`SpanExitMessage`] pairs.
+    pub span_id: Option<SpanId>,
 
     /// The attribute being set
     #[serde(borrow)]
@@ -488,12 +483,14 @@ impl ToStatic for SpanSetAttributeMessage<'_> {
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(feature = "alloc", derive(Deserialize))]
 pub struct SpanAddEventMessage<'a> {
-    /// The span the event is being added to
-    pub span_id: SpanId,
+    /// The span the event is being added to, if [`None`] then this applies to the "current span"
+    /// as determined by tracking [`SpanEnterMessage`] and [`SpanExitMessage`] pairs.
+    pub span_id: Option<SpanId>,
 
     /// The name of the event
     #[serde(borrow)]
     pub name: StringType<'a>,
+
     /// Timestamp when the event occurred
     pub time_unix_nano: u64,
 
@@ -522,8 +519,9 @@ impl ToStatic for SpanAddEventMessage<'_> {
 /// that are not parent-child hierarchies.
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct SpanAddLinkMessage {
-    /// The span the link is being added to
-    pub span_id: SpanId,
+    /// The span the link is being added to, if [`None`] then this applies to the "current span"
+    /// as determined by tracking [`SpanEnterMessage`] and [`SpanExitMessage`] pairs.
+    pub span_id: Option<SpanId>,
 
     /// The span context being linked to
     pub link: SpanContext,
@@ -593,7 +591,7 @@ mod tests {
         let static_str: StringType<'static> = "static".into();
 
         let _event = SpanAddEventMessage {
-            span_id: SpanId(0),
+            span_id: Some(SpanId(0)),
             name: static_str,
             time_unix_nano: 0,
             attributes: attribute_list_from_slice(&[]),
@@ -602,7 +600,7 @@ mod tests {
         let borrowed_str: StringType = "borrowed".into();
 
         let _event = SpanAddEventMessage {
-            span_id: SpanId(0),
+            span_id: Some(SpanId(0)),
             name: borrowed_str,
             time_unix_nano: 0,
             attributes: attribute_list_from_slice(&[]),
@@ -616,7 +614,7 @@ mod tests {
         let owned: StringType<'static> = StringType::from(string);
 
         let _event = SpanAddEventMessage {
-            span_id: SpanId(0),
+            span_id: Some(SpanId(0)),
             name: owned,
             time_unix_nano: 0,
             attributes: attribute_list_from_slice(&[]),
@@ -643,7 +641,7 @@ mod tests {
 
         let attributes = [attribute];
         let span_event = SpanAddEventMessage {
-            span_id: SpanId(0),
+            span_id: Some(SpanId(0)),
             name: borrowed_name,
             time_unix_nano: 0,
             attributes: attribute_list_from_slice(&attributes),

--- a/veecle-telemetry/src/test_helpers.rs
+++ b/veecle-telemetry/src/test_helpers.rs
@@ -6,16 +6,32 @@ use alloc::vec::Vec;
 use crate::SpanId;
 use crate::protocol::{
     InstanceMessage, LogMessage, SpanAddEventMessage, SpanAddLinkMessage, SpanCreateMessage,
-    SpanSetAttributeMessage, TelemetryMessage, TracingMessage,
+    SpanSetAttributeMessage, TelemetryMessage, ThreadId, TracingMessage,
 };
 use crate::value::Value;
 
+struct CreateAndParent<'a> {
+    parent: Option<SpanId>,
+    span_create: SpanCreateMessage<'a>,
+}
+
 struct TelemetryData<'a> {
-    spans: Vec<SpanCreateMessage<'a>>,
-    links: BTreeMap<SpanId, Vec<SpanAddLinkMessage>>,
-    attributes: BTreeMap<SpanId, Vec<SpanSetAttributeMessage<'a>>>,
-    events: BTreeMap<SpanId, Vec<SpanAddEventMessage<'a>>>,
+    spans: Vec<CreateAndParent<'a>>,
+    links: BTreeMap<Option<SpanId>, Vec<SpanAddLinkMessage>>,
+    attributes: BTreeMap<Option<SpanId>, Vec<SpanSetAttributeMessage<'a>>>,
+    events: BTreeMap<Option<SpanId>, Vec<SpanAddEventMessage<'a>>>,
     logs: BTreeMap<Option<SpanId>, Vec<LogMessage<'a>>>,
+    execution_contexts: BTreeMap<ThreadId, Vec<SpanId>>,
+}
+
+impl TelemetryData<'_> {
+    fn context_for(&mut self, thread_id: ThreadId) -> &mut Vec<SpanId> {
+        self.execution_contexts.entry(thread_id).or_default()
+    }
+
+    fn current_span_for(&mut self, thread_id: ThreadId) -> Option<SpanId> {
+        self.context_for(thread_id).last().cloned()
+    }
 }
 
 pub fn format_telemetry_tree(messages: Vec<InstanceMessage>) -> String {
@@ -25,38 +41,58 @@ pub fn format_telemetry_tree(messages: Vec<InstanceMessage>) -> String {
         links: BTreeMap::new(),
         attributes: BTreeMap::new(),
         logs: BTreeMap::new(),
+        execution_contexts: BTreeMap::new(),
     };
 
     for message in messages {
         match message.message {
             TelemetryMessage::Tracing(TracingMessage::CreateSpan(span_create)) => {
-                telemetry_data.spans.push(span_create);
+                let parent = telemetry_data.current_span_for(message.thread_id);
+                telemetry_data.spans.push(CreateAndParent {
+                    parent,
+                    span_create,
+                });
+            }
+            TelemetryMessage::Tracing(TracingMessage::EnterSpan(span_enter)) => {
+                telemetry_data
+                    .context_for(message.thread_id)
+                    .push(span_enter.span_id);
+            }
+            TelemetryMessage::Tracing(TracingMessage::ExitSpan(span_exit)) => {
+                let expected = telemetry_data.context_for(message.thread_id).pop();
+                assert_eq!(Some(span_exit.span_id), expected);
             }
             TelemetryMessage::Tracing(TracingMessage::AddEvent(event)) => {
+                let span_id = event
+                    .span_id
+                    .or_else(|| telemetry_data.current_span_for(message.thread_id));
                 telemetry_data
                     .events
-                    .entry(event.span_id)
+                    .entry(span_id)
                     .or_default()
                     .push(event);
             }
             TelemetryMessage::Tracing(TracingMessage::AddLink(link)) => {
-                telemetry_data
-                    .links
-                    .entry(link.span_id)
-                    .or_default()
-                    .push(link);
+                let span_id = link
+                    .span_id
+                    .or_else(|| telemetry_data.current_span_for(message.thread_id));
+                telemetry_data.links.entry(span_id).or_default().push(link);
             }
             TelemetryMessage::Tracing(TracingMessage::SetAttribute(attr)) => {
+                let span_id = attr
+                    .span_id
+                    .or_else(|| telemetry_data.current_span_for(message.thread_id));
                 telemetry_data
                     .attributes
-                    .entry(attr.span_id)
+                    .entry(span_id)
                     .or_default()
                     .push(attr);
             }
             TelemetryMessage::Log(log_msg) => {
+                let span_id = telemetry_data.current_span_for(message.thread_id);
                 telemetry_data
                     .logs
-                    .entry(log_msg.span_id)
+                    .entry(span_id)
                     .or_default()
                     .push(log_msg);
             }
@@ -108,27 +144,27 @@ fn build_tree_string(
     depth: usize,
     result: &mut String,
 ) {
-    // Find the span with the given span_id
+    // Find the span with the given `parent_span_id`.
     for span in data
         .spans
         .iter()
-        .filter(|s| s.parent_span_id == parent_span_id)
+        .filter(|span| span.parent == parent_span_id)
     {
-        // Add indentation
+        // Add indentation.
         for _ in 0..depth {
             result.push_str("    ");
         }
 
-        // Add span name
-        result.push_str(&span.name);
+        // Add span name.
+        result.push_str(&span.span_create.name);
 
-        // Add creation attributes in brackets
+        // Add creation attributes in brackets.
         result.push_str(" [");
-        format_attributes(span.attributes.iter(), result);
+        format_attributes(span.span_create.attributes.iter(), result);
         result.push_str("]\n");
 
-        // Add span-specific attributes
-        if let Some(span_attrs) = data.attributes.get(&span.span_id) {
+        // Add span-specific attributes.
+        if let Some(span_attrs) = data.attributes.get(&Some(span.span_create.span_id)) {
             for attr_msg in span_attrs {
                 for _ in 0..=depth {
                     result.push_str("    ");
@@ -141,8 +177,8 @@ fn build_tree_string(
             }
         }
 
-        // Add span links
-        if let Some(span_links) = data.links.get(&span.span_id) {
+        // Add span links.
+        if let Some(span_links) = data.links.get(&Some(span.span_create.span_id)) {
             for link_msg in span_links {
                 for _ in 0..=depth {
                     result.push_str("    ");
@@ -151,8 +187,8 @@ fn build_tree_string(
             }
         }
 
-        // Add span events
-        if let Some(span_events) = data.events.get(&span.span_id) {
+        // Add span events.
+        if let Some(span_events) = data.events.get(&Some(span.span_create.span_id)) {
             for event in span_events {
                 for _ in 0..=depth {
                     result.push_str("    ");
@@ -165,8 +201,8 @@ fn build_tree_string(
             }
         }
 
-        // Add span logs
-        if let Some(span_logs) = data.logs.get(&Some(span.span_id)) {
+        // Add span logs.
+        if let Some(span_logs) = data.logs.get(&Some(span.span_create.span_id)) {
             for log_msg in span_logs {
                 for _ in 0..=depth {
                     result.push_str("    ");
@@ -180,10 +216,10 @@ fn build_tree_string(
             }
         }
 
-        build_tree_string(data, Some(span.span_id), depth + 1, result);
+        build_tree_string(data, Some(span.span_create.span_id), depth + 1, result);
     }
 
-    // Add unattached logs (logs without trace/span context) at root level
+    // Add unattached logs (logs without trace/span context) at root level.
     if depth == 0
         && let Some(unattached_logs) = data.logs.get(&None)
     {


### PR DESCRIPTION
Remove the thread-local `CURRENT_SPAN` tracking and `SpanContext::current` method. Span context is now determined by thread id rather than explicit parent-child span relationships.

This simplifies the telemetry model by eliminating implicit state within the process. Span messages are correlated through their thread id, which provides sufficient context for external tools to reconstruct the span relationships.

Closes: DEV-911