### PR TITLE
chore!: rename `InstanceMessage::thread` to `thread_id`

### DIFF
--- a/veecle-ipc/src/telemetry.rs
+++ b/veecle-ipc/src/telemetry.rs
@@ -50,7 +50,7 @@ mod tests {
         let exporter = Exporter::new(sender);
 
         let test_message = InstanceMessage {
-            thread: THREAD_ID,
+            thread_id: THREAD_ID,
             message: TelemetryMessage::Log(LogMessage {
                 time_unix_nano: 1000000000,
                 severity: Severity::Info,
@@ -65,7 +65,7 @@ mod tests {
         let received = receiver.recv().await.expect("should receive message");
         match received {
             veecle_ipc_protocol::Message::Telemetry(message) => {
-                assert_eq!(message.thread, THREAD_ID);
+                assert_eq!(message.thread_id, THREAD_ID);
                 match message.message {
                     TelemetryMessage::Log(message) => {
                         assert_eq!(message.time_unix_nano, 1000000000);
@@ -88,7 +88,7 @@ mod tests {
         drop(receiver);
 
         let test_message = InstanceMessage {
-            thread: THREAD_ID,
+            thread_id: THREAD_ID,
             message: TelemetryMessage::Log(LogMessage {
                 time_unix_nano: 2000000000,
                 severity: Severity::Error,

--- a/veecle-telemetry-ui/src/store/mod.rs
+++ b/veecle-telemetry-ui/src/store/mod.rs
@@ -172,7 +172,7 @@ impl Store {
 
         let InstanceMessage {
             // TODO(DEV-605): support filtering by thread.
-            thread,
+            thread_id: thread,
             message,
         } = instance_message;
 

--- a/veecle-telemetry/src/collector/mod.rs
+++ b/veecle-telemetry/src/collector/mod.rs
@@ -255,7 +255,7 @@ impl Collector {
     ///
     /// let collector = get_collector();
     /// let message = InstanceMessage {
-    ///     thread: ThreadId::from_raw(ProcessId::from_raw(1), NonZeroU64::new(1).unwrap()),
+    ///     thread_id: ThreadId::from_raw(ProcessId::from_raw(1), NonZeroU64::new(1).unwrap()),
     ///     message: TelemetryMessage::TimeSync(TimeSyncMessage {
     ///         local_timestamp: 0,
     ///         since_epoch: 0,
@@ -306,7 +306,7 @@ impl Collector {
     #[inline]
     pub(crate) fn log_message(&self, log: LogMessage<'_>) {
         self.inner.exporter.export(InstanceMessage {
-            thread: ThreadId::current(self.inner.process_id),
+            thread_id: ThreadId::current(self.inner.process_id),
             message: TelemetryMessage::Log(log),
         });
     }
@@ -314,7 +314,7 @@ impl Collector {
     #[inline]
     fn tracing_message(&self, message: TracingMessage<'_>) {
         self.inner.exporter.export(InstanceMessage {
-            thread: ThreadId::current(self.inner.process_id),
+            thread_id: ThreadId::current(self.inner.process_id),
             message: TelemetryMessage::Tracing(message),
         });
     }

--- a/veecle-telemetry/src/protocol.rs
+++ b/veecle-telemetry/src/protocol.rs
@@ -108,7 +108,7 @@ impl ThreadId {
 #[cfg_attr(feature = "alloc", derive(Deserialize))]
 pub struct InstanceMessage<'a> {
     /// The thread this message belongs to
-    pub thread: ThreadId,
+    pub thread_id: ThreadId,
 
     /// The telemetry message content
     #[serde(borrow)]
@@ -121,7 +121,7 @@ impl ToStatic for InstanceMessage<'_> {
 
     fn to_static(&self) -> Self::Static {
         InstanceMessage {
-            thread: self.thread,
+            thread_id: self.thread_id,
             message: self.message.to_static(),
         }
     }
@@ -485,7 +485,7 @@ mod tests {
         let tracing_message = TracingMessage::AddEvent(span_event);
         let telemetry_message = TelemetryMessage::Tracing(tracing_message);
         let instance_message = InstanceMessage {
-            thread: ThreadId::from_raw(ProcessId::from_raw(999), NonZeroU64::new(111).unwrap()),
+            thread_id: ThreadId::from_raw(ProcessId::from_raw(999), NonZeroU64::new(111).unwrap()),
             message: telemetry_message,
         };
 


### PR DESCRIPTION
Small naming cleanup