### PR TITLE
chore: run tombi in offline mode

### DIFF
--- a/workspace/tests/checks.rs
+++ b/workspace/tests/checks.rs
@@ -410,13 +410,13 @@ fn main() -> std::process::ExitCode {
         vec![
             Trial::test("veecle_os::tombi::fmt", move || {
                 Command::new("tombi")
-                    .args(["format", "--check"])
+                    .args(["format", "--offline", "--check"])
                     .current_dir(manifest_dir)
                     .run_as_test(capture)
             }),
             Trial::test("veecle_os::tombi::lint", move || {
                 Command::new("tombi")
-                    .args(["lint"])
+                    .args(["lint", "--offline"])
                     .current_dir(manifest_dir)
                     .run_as_test(capture)
             }),


### PR DESCRIPTION
There was an error in one CI job (https://github.com/veecle/veecle-os/actions/runs/19131389848/job/54672749427):

```
Error: failed to fetch catalog: https://json.schemastore.org/api/json/catalog.json, reason: unexpected status: 503
```

I believe we are using internal schemas only so it shouldn't need to download anything.