### PR TITLE
feat(telemetry-ui): Gray out filtered spans instead of hiding them

### DIFF
--- a/veecle-telemetry-ui/src/filter.rs
+++ b/veecle-telemetry-ui/src/filter.rs
@@ -91,9 +91,21 @@ impl Filters {
         })
     }
 
-    pub fn filter_root_spans<'a>(&'a self, store: &'a Store) -> impl Iterator<Item = SpanRef<'a>> {
-        store
-            .root_spans()
-            .filter(|span| self.actor.is_empty() || self.actor.matches(&span.actor))
+    /// Check if a span matches current filters
+    pub fn span_matches(&self, span: &SpanRef) -> bool {
+        self.target.matches(&span.metadata.target)
+            && self
+                .file
+                .matches(span.metadata.file.as_deref().unwrap_or_default())
+            && self.actor.matches(&span.actor)
+    }
+
+    /// Check if any filters are activate
+    pub fn has_active_filters(&self) -> bool {
+        !self.target.is_empty()
+            || !self.file.is_empty()
+            || !self.actor.is_empty()
+            || !self.level.is_empty()
+            || !self.message.is_empty()
     }
 }

--- a/veecle-telemetry-ui/src/ui/timeline/mod.rs
+++ b/veecle-telemetry-ui/src/ui/timeline/mod.rs
@@ -438,7 +438,7 @@ impl TraceTimelinePanel {
 
                 let mut span_metadata = SpanUiMetadata::default();
 
-                let data = convert(app_state, store);
+                let data = convert(store);
                 for (actor_name, data) in &data.actors {
                     self.show_collapsing_actor(
                         time_area_response,
@@ -447,6 +447,7 @@ impl TraceTimelinePanel {
                         data,
                         app_state.selection(),
                         &mut span_metadata,
+                        app_state,
                         ui,
                     );
                 }
@@ -464,6 +465,7 @@ impl TraceTimelinePanel {
         actor: &Vec<ActorSpanRow>,
         selection_state: &SelectionState,
         span_metadata: &mut SpanUiMetadata,
+        app_state: &AppState,
         ui: &mut egui::Ui,
     ) {
         let is_expanded = !self.collapsed_actors.contains(actor_name);
@@ -603,6 +605,7 @@ impl TraceTimelinePanel {
                 time_area_response,
                 time_area_painter,
                 span_metadata,
+                app_state.filter(),
             );
 
             top = bottom;
@@ -810,13 +813,13 @@ fn span_depth(span: SpanRef) -> usize {
         + 1
 }
 
-fn convert<'a>(app_state: &'a AppState, store: &'a Store) -> SelectedData<'a> {
+fn convert<'a>(store: &'a Store) -> SelectedData<'a> {
     let mut selected = SelectedData {
         range: (Timestamp::MAX, Timestamp::MIN),
         actors: Default::default(),
     };
 
-    for span in app_state.filter().filter_root_spans(store) {
+    for span in store.root_spans() {
         // update range
         selected.range.0 = selected.range.0.min(span.start);
         selected.range.1 = selected.range.1.max(span.end);


### PR DESCRIPTION
Instead of completely hiding spans that don't match active filters, they are now displayed but are visuall grayed out.

Matching spans that are matched by the filter maintain 40% of the grayness, but filtered-out spans are being dimed out (15% gray) with reduced opacity to indicate that they are filtered out.

Demo:

https://github.com/user-attachments/assets/450c006d-9103-46e5-a538-b9a8951ecb76

Resolves: https://github.com/veecle/veecle-os/issues/138