### PR TITLE
feat(telemetry-ui): Add outline highlighting for selected spans

### DIFF
--- a/veecle-telemetry-ui/src/ui/timeline/traces.rs
+++ b/veecle-telemetry-ui/src/ui/timeline/traces.rs
@@ -420,7 +420,7 @@ fn paint_record(
         // use outline for selected span
         if is_selected {
             let outline_color = Color32::from_rgb(120, 170, 255);
-            let outline_stroke = Stroke::new(2.0, outline_color);
+            let outline_stroke = Stroke::new(2.5, outline_color);
             info.painter.rect(
                 draw_rect,
                 RECT_ROUNDING,


### PR DESCRIPTION
Added a 2px amber(?) outline around selected spans in the timeline to make them more visually distinct.

Demo:

https://github.com/user-attachments/assets/4d55555f-1898-4874-94e2-c060f86a8dfd

Resolves: https://github.com/veecle/veecle-os/issues/139