### PR TITLE
fix: hide `ConsoleJsonExporter` internals to allow future changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * **breaking** Removed `Span::root` method and `root_span!` macro; root spans should use `Span::new` and `span!` instead.
 * **breaking** Replaced `SpanContext::from_span` with `Span::context` method.
 * **breaking** Telemetry execution id is replaced by separate thread and process ids to uniquely identify thread/task combinations.
+* **breaking** `ConsoleJsonExporter` is no longer a unit struct, replace usage with `ConsoleJsonExporter::DEFAULT`.
 * Added custom serialization for telemetry ids with hex-encoded string format.
 * Added `ThreadAbstraction` trait to OSAL for querying current thread id.
 * Updated MSRV to 1.91.

--- a/veecle-os-examples/embassy-std/src/main.rs
+++ b/veecle-os-examples/embassy-std/src/main.rs
@@ -18,7 +18,7 @@ async fn run() {
 async fn main(spawner: Spawner) {
     veecle_os::telemetry::collector::set_exporter(
         veecle_os::telemetry::collector::ProcessId::random(&mut rand::rng()),
-        &veecle_os::telemetry::collector::ConsoleJsonExporter,
+        &veecle_os::telemetry::collector::ConsoleJsonExporter::DEFAULT,
     )
     .unwrap();
 

--- a/veecle-os-examples/freertos-linux/src/bin/alloc.rs
+++ b/veecle-os-examples/freertos-linux/src/bin/alloc.rs
@@ -21,7 +21,7 @@ async fn alloc_stat_actor() -> Infallible {
 pub fn main() -> ! {
     veecle_os::telemetry::collector::set_exporter(
         veecle_os::telemetry::collector::ProcessId::random(&mut rand::rng()),
-        &veecle_os::telemetry::collector::ConsoleJsonExporter,
+        &veecle_os::telemetry::collector::ConsoleJsonExporter::DEFAULT,
     )
     .unwrap();
 

--- a/veecle-os-examples/freertos-linux/src/bin/queues.rs
+++ b/veecle-os-examples/freertos-linux/src/bin/queues.rs
@@ -33,7 +33,7 @@ async fn queue_actor(
 fn main() {
     veecle_os::telemetry::collector::set_exporter(
         veecle_os::telemetry::collector::ProcessId::random(&mut rand::rng()),
-        &veecle_os::telemetry::collector::ConsoleJsonExporter,
+        &veecle_os::telemetry::collector::ConsoleJsonExporter::DEFAULT,
     )
     .unwrap();
 

--- a/veecle-os-examples/freertos-linux/src/bin/time.rs
+++ b/veecle-os-examples/freertos-linux/src/bin/time.rs
@@ -10,7 +10,7 @@ static GLOBAL: FreeRtosAllocator = unsafe { FreeRtosAllocator::new() };
 pub fn main() -> ! {
     veecle_os::telemetry::collector::set_exporter(
         veecle_os::telemetry::collector::ProcessId::random(&mut rand::rng()),
-        &veecle_os::telemetry::collector::ConsoleJsonExporter,
+        &veecle_os::telemetry::collector::ConsoleJsonExporter::DEFAULT,
     )
     .unwrap();
 

--- a/veecle-osal-std-macros/src/main_impl.rs
+++ b/veecle-osal-std-macros/src/main_impl.rs
@@ -73,7 +73,7 @@ fn impl_main(
                 #veecle_telemetry_path::collector::ProcessId::random(
                     &mut #veecle_osal_std_path::reexports::rand::rng(),
                 ),
-                &#veecle_telemetry_path::collector::ConsoleJsonExporter
+                &#veecle_telemetry_path::collector::ConsoleJsonExporter::DEFAULT,
             )
             .unwrap();
         )

--- a/veecle-telemetry-ui/examples/continuous.rs
+++ b/veecle-telemetry-ui/examples/continuous.rs
@@ -34,7 +34,7 @@ async fn ping_actor(
 #[veecle_osal_std::main]
 async fn main() {
     let process_id = ProcessId::random(&mut rand::rng());
-    veecle_telemetry::collector::set_exporter(process_id, &ConsoleJsonExporter)
+    veecle_telemetry::collector::set_exporter(process_id, &ConsoleJsonExporter::DEFAULT)
         .expect("exporter was not set yet");
 
     veecle_os_runtime::execute! {

--- a/veecle-telemetry-ui/examples/remote.rs
+++ b/veecle-telemetry-ui/examples/remote.rs
@@ -34,7 +34,7 @@ pub async fn ping_actor(mut ping: Writer<'_, Ping>, mut pong: Reader<'_, Pong>) 
 #[veecle_osal_std::main]
 async fn main() {
     let process_id = ProcessId::random(&mut rand::rng());
-    veecle_telemetry::collector::set_exporter(process_id, &ConsoleJsonExporter)
+    veecle_telemetry::collector::set_exporter(process_id, &ConsoleJsonExporter::DEFAULT)
         .expect("exporter was not set yet");
 
     veecle_os_runtime::execute! {

--- a/veecle-telemetry/examples/async.rs
+++ b/veecle-telemetry/examples/async.rs
@@ -8,7 +8,7 @@ use veecle_telemetry::{CurrentSpan, Span};
 #[tokio::main]
 async fn main() {
     let process_id = ProcessId::random(&mut rand::rng());
-    veecle_telemetry::collector::set_exporter(process_id, &ConsoleJsonExporter)
+    veecle_telemetry::collector::set_exporter(process_id, &ConsoleJsonExporter::DEFAULT)
         .expect("exporter was not set yet");
 
     let _span = Span::new("main", &[]).entered();

--- a/veecle-telemetry/examples/basic.rs
+++ b/veecle-telemetry/examples/basic.rs
@@ -5,7 +5,7 @@ use veecle_telemetry::collector::{ConsoleJsonExporter, ProcessId};
 
 fn main() {
     let process_id = ProcessId::random(&mut rand::rng());
-    veecle_telemetry::collector::set_exporter(process_id, &ConsoleJsonExporter)
+    veecle_telemetry::collector::set_exporter(process_id, &ConsoleJsonExporter::DEFAULT)
         .expect("exporter was not set yet");
 
     let _span = Span::new("main", &[]).entered();

--- a/veecle-telemetry/src/collector/json_exporter.rs
+++ b/veecle-telemetry/src/collector/json_exporter.rs
@@ -9,10 +9,15 @@ use crate::protocol::InstanceMessage;
 /// use veecle_telemetry::collector::{ConsoleJsonExporter, set_exporter, ProcessId};
 ///
 /// let process_id = ProcessId::random(&mut rand::rng());
-/// set_exporter(process_id, &ConsoleJsonExporter).unwrap();
+/// set_exporter(process_id, &ConsoleJsonExporter::DEFAULT).unwrap();
 /// ```
-#[derive(Debug)]
-pub struct ConsoleJsonExporter;
+#[derive(Debug, Default)]
+pub struct ConsoleJsonExporter(());
+
+impl ConsoleJsonExporter {
+    /// A `const` version of `ConsoleJsonExporter::default()` to allow use as a `&'static`.
+    pub const DEFAULT: Self = ConsoleJsonExporter(());
+}
 
 impl Export for ConsoleJsonExporter {
     fn export(&self, message: InstanceMessage) {

--- a/veecle-telemetry/src/lib.rs
+++ b/veecle-telemetry/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let process_id = ProcessId::random(&mut rand::rng());
-//! set_exporter(process_id, &ConsoleJsonExporter)?;
+//! set_exporter(process_id, &ConsoleJsonExporter::DEFAULT)?;
 //! # Ok(())
 //! # }
 //! ```


### PR DESCRIPTION
From https://github.com/veecle/veecle-os/pull/107#discussion_r2522385724.