### PR TITLE
fix(telemetry-ui): Prevent tooltip flickering on spans with long names

### DIFF
--- a/veecle-telemetry-ui/src/ui/timeline/traces.rs
+++ b/veecle-telemetry-ui/src/ui/timeline/traces.rs
@@ -300,7 +300,10 @@ fn paint_scope_details(ui: &mut egui::Ui, span: SpanRef, max: Timestamp) {
             ui.end_row();
 
             ui.monospace("operation name");
-            ui.monospace(span.metadata.name.as_str());
+            ui.add(
+                egui::Label::new(egui::RichText::new(span.metadata.name.as_str()).monospace())
+                    .wrap_mode(egui::TextWrapMode::Wrap),
+            );
             ui.end_row();
 
             ui.monospace("duration");


### PR DESCRIPTION
When hovering over spans with very long operation names, the tooltip would continously blink/flicker, making it impossible to read. Spans with shorter name did not exhibit this behavior.

Assumably the root cause here was that the tooltip displayed long operation names without any text wrapping so when the wide tooltip rendered, it would overlap and cover the span rectangle that the user was hovering on, and this created a feedback loop, which was looking like blinking.

So, this patch enables text wrapping for the operation name field in the tooltip by using `egui::Label` with `TextWrapMode::Wrap` instead of the simple `ui.monospace()`. This basically breaks long operation names across multiple lines.

Before:

https://github.com/user-attachments/assets/995233d2-90a5-49b1-b115-11ffcf7cf5dc

After:

https://github.com/user-attachments/assets/3402b299-db43-4246-bd35-50ed79464445

