### PR TITLE
feat: add support for yoke to MemoryPool and SOME/IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Added `ThreadAbstraction` trait to OSAL for querying current thread id.
 * Updated MSRV to 1.91.
 * Fixed `veecle_os::telemetry::instrument` macro to automatically resolve correct crate paths for the facade.
+* Implemented `stable_deref_trait::StableDeref` for `Chunk` to allow usage in `yoke`.
 
 ## Veecle Telemetry
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4117,9 +4117,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -4909,6 +4909,9 @@ dependencies = [
  "pretty_assertions",
  "thiserror 2.0.17",
  "veecle-os-data-support-someip-macros",
+ "veecle-os-runtime 0.1.0",
+ "veecle-os-test",
+ "yoke",
 ]
 
 [[package]]
@@ -4931,6 +4934,7 @@ dependencies = [
  "generic-array 1.3.5",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "tokio",
  "trybuild",
  "typenum",
@@ -6065,11 +6069,10 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ someip-test-service = { path = "someip-test-service", version = "0.1.0", default
 someip-test-service-macro = { path = "someip-test-service-macro", version = "0.1.0", default-features = false }
 someip-test-service-sys = { path = "someip-test-service-sys", version = "0.1.0", default-features = false }
 someip-test-service-tests = { path = "someip-test-service-tests", version = "0.1.0", default-features = false }
+stable_deref_trait = { version = "1.2.1", default-features = false }
 static_cell = { version = "2.1.1", default-features = false }
 strum = { version = "0.27.2", default-features = false }
 syn = { version = "2.0.111", default-features = false }
@@ -169,6 +170,7 @@ walkdir = { version = "2.5.0", default-features = false }
 wasm-bindgen-futures = { version = "0.4.56", default-features = false }
 web-sys = { version = "0.3.78", default-features = false }
 web-time = { version = "1.1.0", default-features = false }
+yoke = { version = "0.8.1", default-features = false }
 
 [workspace.lints.clippy]
 alloc_instead_of_core = "warn"

--- a/docs/user-manual/crates/getting-started/Cargo.lock
+++ b/docs/user-manual/crates/getting-started/Cargo.lock
@@ -576,6 +576,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +692,7 @@ dependencies = [
  "generic-array",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "typenum",
  "veecle-os-runtime-macros",
  "veecle-telemetry",

--- a/docs/user-manual/crates/traces-serialization/Cargo.lock
+++ b/docs/user-manual/crates/traces-serialization/Cargo.lock
@@ -627,6 +627,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +752,7 @@ dependencies = [
  "generic-array",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "typenum",
  "veecle-os-runtime-macros",
  "veecle-telemetry",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1681,7 +1681,7 @@ version = "0.6.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.stable_deref_trait]]
-version = "1.2.0"
+version = "1.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.static_assertions]]
@@ -2273,7 +2273,7 @@ version = "1.0.1"
 criteria = "safe-to-run"
 
 [[exemptions.yoke]]
-version = "0.8.0"
+version = "0.8.1"
 criteria = "safe-to-run"
 
 [[exemptions.yoke-derive]]

--- a/veecle-os-data-support-can/test-crates/veecle-os-crate/Cargo.lock
+++ b/veecle-os-data-support-can/test-crates/veecle-os-crate/Cargo.lock
@@ -487,6 +487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +647,7 @@ dependencies = [
  "generic-array 1.3.5",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "typenum",
  "veecle-os-runtime-macros",
  "veecle-telemetry",

--- a/veecle-os-data-support-someip-macros/test-crates/veecle-os-crate/Cargo.lock
+++ b/veecle-os-data-support-someip-macros/test-crates/veecle-os-crate/Cargo.lock
@@ -312,6 +312,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +440,7 @@ dependencies = [
  "generic-array",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "typenum",
  "veecle-os-runtime-macros",
  "veecle-telemetry",

--- a/veecle-os-data-support-someip/Cargo.toml
+++ b/veecle-os-data-support-someip/Cargo.toml
@@ -25,6 +25,9 @@ veecle-os-data-support-someip-macros = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true, features = ["std"] }
+veecle-os-runtime = { workspace = true }
+veecle-os-test = { workspace = true }
+yoke = { workspace = true, features = ["derive"] }
 
 [lints]
 workspace = true

--- a/veecle-os-data-support-someip/src/header.rs
+++ b/veecle-os-data-support-someip/src/header.rs
@@ -423,6 +423,11 @@ impl<'a> Payload<'a> {
     pub fn new(bytes: &'a [u8]) -> Self {
         Self(bytes)
     }
+
+    /// Returns the internal payload slice.
+    pub fn into_inner(self) -> &'a [u8] {
+        self.0
+    }
 }
 
 /// SOME/IP header.
@@ -631,6 +636,14 @@ mod tests {
 
         let payload = Payload::from(payload_data.as_slice());
         assert_eq!(payload.as_ref(), payload_data);
+    }
+
+    #[test]
+    fn payload_into_inner() {
+        let payload_data = [10, 20, 30];
+
+        let payload = Payload::new(payload_data.as_slice());
+        assert_eq!(payload.into_inner(), payload_data);
     }
 
     #[test]

--- a/veecle-os-data-support-someip/tests/move_between_actors.rs
+++ b/veecle-os-data-support-someip/tests/move_between_actors.rs
@@ -1,0 +1,88 @@
+//! Tests whether a deserialized payload can be moved between actors without copy.
+
+use std::convert::Infallible;
+use veecle_os_data_support_someip::header::*;
+use veecle_os_data_support_someip::parse::ParseExt;
+use veecle_os_data_support_someip::service_discovery;
+use veecle_os_data_support_someip::service_discovery::{Entry, ServiceEntry};
+use veecle_os_runtime::actor;
+use veecle_os_runtime::memory_pool::{Chunk, MemoryPool};
+use veecle_os_runtime::{ExclusiveReader, Storable, Writer};
+use yoke::{Yoke, Yokeable};
+
+#[test]
+fn yoke() {
+    // Raw SOME/IP service discovery message.
+    // First 16 bytes is a header, rest is a service discovery header.
+    const BYTES: &[u8; 84] = &[
+        255, 128, 129, 0, 0, 0, 0, 76, 0, 0, 20, 147, 1, 1, 2, 0, 64, 0, 0, 0, 0, 0, 0, 32, 1, 0,
+        0, 16, 3, 232, 0, 10, 1, 0, 0, 128, 0, 0, 0, 0, 1, 1, 0, 16, 3, 235, 0, 10, 1, 0, 0, 128,
+        0, 0, 0, 0, 0, 0, 0, 24, 0, 9, 4, 0, 192, 0, 2, 0, 0, 17, 0, 24, 0, 9, 4, 0, 192, 0, 2, 0,
+        0, 17, 0, 26,
+    ];
+
+    static POOL: MemoryPool<[u8; 84], 5> = MemoryPool::new();
+
+    #[derive(Debug, Storable)]
+    #[storable(data_type = "Chunk<'static, [u8; 84]>")]
+    pub struct Input;
+
+    #[derive(Debug, Storable)]
+    #[storable(data_type = "Yoke<YokeWrapper<'static>, Chunk<'static, [u8; 84]>>")]
+    pub struct Output;
+
+    #[derive(Debug, Yokeable)]
+    pub struct YokeWrapper<'a>(service_discovery::Header<'a>);
+
+    #[actor]
+    async fn deserializer(
+        mut input: ExclusiveReader<'_, Input>,
+        mut writer: Writer<'_, Output>,
+    ) -> Infallible {
+        loop {
+            input.wait_for_update().await;
+            let Some(bytes) = input.take() else { continue };
+            let yoked: Yoke<YokeWrapper, Chunk<'static, [u8; 84]>> =
+                Yoke::attach_to_cart(bytes, |bytes| {
+                    let (_header, payload) = Header::parse_with_payload(bytes.as_ref())
+                        .expect("failed to parse SOME/IP message");
+
+                    YokeWrapper(
+                        service_discovery::Header::parse(payload.into_inner())
+                            .expect("failed to deserialize SOME/IP service discovery header"),
+                    )
+                });
+
+            writer.write(yoked).await;
+        }
+    }
+
+    veecle_os_test::block_on_future(veecle_os_test::execute! {
+        store: [Input, Output],
+        actors: [
+            Deserializer,
+        ],
+        validation: async |mut writer: Writer<'a, Input>, mut reader: ExclusiveReader<'a, Output>| {
+            async {
+                let chunk = POOL.chunk(*BYTES).unwrap();
+                writer.write(chunk).await;
+                let deserialized = reader.wait_for_update().await.take().unwrap();
+                let expected_entry = Entry::OfferService(
+                    ServiceEntry {
+                        first_option: 0x00,
+                        second_option: 0x00,
+                        option_counts: 16,
+                        service_id: 0x03E8,
+                        instance_id: 0x000A,
+                        major_version_ttl: 0x1000080,
+                        minor_version: 0,
+                    }
+                );
+                assert_eq!(
+                    deserialized.get().0.entries.iter().next().unwrap(),
+                    expected_entry
+                );
+            }.await;
+        }
+    });
+}

--- a/veecle-os-examples/common/Cargo.lock
+++ b/veecle-os-examples/common/Cargo.lock
@@ -331,6 +331,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +422,7 @@ dependencies = [
  "generic-array",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "typenum",
  "veecle-os-runtime-macros",
  "veecle-telemetry",

--- a/veecle-os-examples/embassy-std/Cargo.lock
+++ b/veecle-os-examples/embassy-std/Cargo.lock
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -935,6 +935,7 @@ dependencies = [
  "generic-array",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "typenum",
  "veecle-os-runtime-macros",
  "veecle-telemetry",

--- a/veecle-os-examples/embassy-stm32/Cargo.lock
+++ b/veecle-os-examples/embassy-stm32/Cargo.lock
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1042,6 +1042,7 @@ dependencies = [
  "generic-array",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "typenum",
  "veecle-os-runtime-macros",
  "veecle-telemetry",

--- a/veecle-os-examples/freertos-linux/Cargo.lock
+++ b/veecle-os-examples/freertos-linux/Cargo.lock
@@ -768,6 +768,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +936,7 @@ dependencies = [
  "generic-array",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "typenum",
  "veecle-os-runtime-macros",
  "veecle-telemetry",

--- a/veecle-os-examples/freertos-stm32/Cargo.lock
+++ b/veecle-os-examples/freertos-stm32/Cargo.lock
@@ -756,9 +756,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stm32-fmc"
@@ -959,6 +959,7 @@ dependencies = [
  "generic-array",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "typenum",
  "veecle-os-runtime-macros",
  "veecle-telemetry",

--- a/veecle-os-examples/orchestrator-ipc/Cargo.lock
+++ b/veecle-os-examples/orchestrator-ipc/Cargo.lock
@@ -514,6 +514,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +716,7 @@ dependencies = [
  "generic-array",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "typenum",
  "veecle-os-runtime-macros",
  "veecle-telemetry",

--- a/veecle-os-examples/std/Cargo.lock
+++ b/veecle-os-examples/std/Cargo.lock
@@ -497,6 +497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "stats_alloc"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +633,7 @@ dependencies = [
  "generic-array",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "typenum",
  "veecle-os-runtime-macros",
  "veecle-telemetry",

--- a/veecle-os-runtime-macros/test-crates/auto-renamed-crate/Cargo.lock
+++ b/veecle-os-runtime-macros/test-crates/auto-renamed-crate/Cargo.lock
@@ -298,6 +298,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +370,7 @@ dependencies = [
  "generic-array",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "typenum",
  "veecle-os-runtime-macros",
  "veecle-telemetry",

--- a/veecle-os-runtime-macros/test-crates/veecle-os-crate/Cargo.lock
+++ b/veecle-os-runtime-macros/test-crates/veecle-os-crate/Cargo.lock
@@ -306,6 +306,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +394,7 @@ dependencies = [
  "generic-array",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "typenum",
  "veecle-os-runtime-macros",
  "veecle-telemetry",

--- a/veecle-os-runtime/Cargo.toml
+++ b/veecle-os-runtime/Cargo.toml
@@ -19,6 +19,7 @@ futures = { workspace = true, features = ["async-await"] }
 generic-array = { workspace = true }
 pin-cell = { workspace = true }
 pin-project = { workspace = true }
+stable_deref_trait = { workspace = true }
 typenum = { workspace = true, features = ["const-generics"] }
 veecle-os-runtime-macros = { workspace = true }
 veecle-telemetry = { workspace = true }

--- a/veecle-os-runtime/src/memory_pool.rs
+++ b/veecle-os-runtime/src/memory_pool.rs
@@ -252,6 +252,13 @@ pub struct Chunk<'a, T> {
     token: &'a AtomicBool,
 }
 
+// Required so `Chunk` can be used in `yoke::Yoke` as the cart.
+// SAFETY: While `Chunk` has a reference to its assigned memory location in the `MemoryPool`,
+// the address of that memory cannot change as a reference to the `MemoryPool` instance is held.
+// With that, the address returned by the `Deref` and `DerefMut` implementations
+// are stable for the duration of the lifetime of `Chunk`.
+unsafe impl<'a, T> stable_deref_trait::StableDeref for Chunk<'a, T> {}
+
 impl<T> Debug for Chunk<'_, T>
 where
     T: Debug,

--- a/veecle-osal-std-macros/test-crates/veecle-os-crate/Cargo.lock
+++ b/veecle-osal-std-macros/test-crates/veecle-os-crate/Cargo.lock
@@ -497,6 +497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +614,7 @@ dependencies = [
  "generic-array",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "typenum",
  "veecle-os-runtime-macros",
  "veecle-telemetry",

--- a/veecle-telemetry-macros/test-crates/veecle-os-crate/Cargo.lock
+++ b/veecle-telemetry-macros/test-crates/veecle-os-crate/Cargo.lock
@@ -497,6 +497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +614,7 @@ dependencies = [
  "generic-array",
  "pin-cell",
  "pin-project",
+ "stable_deref_trait",
  "typenum",
  "veecle-os-runtime-macros",
  "veecle-telemetry",


### PR DESCRIPTION
* Implements `StableDeref` for `Chunk` to make it usable with `yoke`.
* Adds `into_inner` method to access a SOME/IP payload's inner reference without reborrowing.
* Adds `move_between_actors` test to verify a deserialized payload can be moved with copies with the `MemoryPool`.

Fixes: DEV-304