### PR TITLE
fix!: make `SerializeExt::serialize` match its docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 
 * **breaking** Removed.
 
+## Veecle OS Data Support SOME/IP
+
+* **breaking** Change return type of `veecle_os_data_support_someip::serialize::SerializeExt::serialize` to match its documentation.
+
 # 0.1.0
 
 * Initial release.

--- a/veecle-os-data-support-someip-macros/src/lib.rs
+++ b/veecle-os-data-support-someip-macros/src/lib.rs
@@ -104,9 +104,9 @@ pub fn someip_parse(input: TokenStream) -> TokenStream {
 /// let bytes = &[0x0, 0x6, 0x1, 0x2, 0x3, 0x4];
 ///
 /// let mut buffer = [0u8; 16];
-/// let output = input.serialize(&mut buffer).unwrap();
+/// let written = input.serialize(&mut buffer).unwrap();
 ///
-/// assert_eq!(output, bytes);
+/// assert_eq!(&buffer[..written], bytes);
 /// ```
 ///
 /// Zero sized types and tuple structs can be derived as well.

--- a/veecle-os-data-support-someip-macros/test-crates/auto-renamed-crate/src/lib.rs
+++ b/veecle-os-data-support-someip-macros/test-crates/auto-renamed-crate/src/lib.rs
@@ -20,7 +20,7 @@ mod tests {
         let mut buffer = [0; 512];
 
         let value = TestStruct { inner: 5 };
-        let serialized = value.serialize(&mut buffer).unwrap();
-        assert_eq!(TestStruct::parse(serialized).unwrap(), value);
+        let written = value.serialize(&mut buffer).unwrap();
+        assert_eq!(TestStruct::parse(&buffer[..written]).unwrap(), value);
     }
 }

--- a/veecle-os-data-support-someip-macros/test-crates/veecle-os-crate/src/lib.rs
+++ b/veecle-os-data-support-someip-macros/test-crates/veecle-os-crate/src/lib.rs
@@ -19,7 +19,7 @@ mod tests {
         let mut buffer = [0; 512];
 
         let value = TestStruct { inner: 5 };
-        let serialized = value.serialize(&mut buffer).unwrap();
-        assert_eq!(TestStruct::parse(serialized).unwrap(), value);
+        let written = value.serialize(&mut buffer).unwrap();
+        assert_eq!(TestStruct::parse(&buffer[..written]).unwrap(), value);
     }
 }

--- a/veecle-os-data-support-someip/src/lib.rs
+++ b/veecle-os-data-support-someip/src/lib.rs
@@ -12,11 +12,10 @@ macro_rules! test_round_trip {
         // Serialize valid.
         let mut buffer = [0u8; 2048];
         let buffer_length = crate::serialize::Serialize::required_length(&value);
-        let serialized_data = crate::serialize::SerializeExt::serialize(&value, &mut buffer);
+        let serialized_length =
+            crate::serialize::SerializeExt::serialize(&value, &mut buffer).unwrap();
 
-        assert!(matches!(serialized_data, Ok(..)));
-
-        let serialized_data = serialized_data.unwrap();
+        let serialized_data = &buffer[..serialized_length];
 
         // Required length.
 

--- a/veecle-os-data-support-someip/src/serialize.rs
+++ b/veecle-os-data-support-someip/src/serialize.rs
@@ -138,16 +138,16 @@ pub trait Serialize {
 pub trait SerializeExt: Sized {
     /// Serializes a SOME/IP payload type to a given slice of bytes using [`Serialize`] and returns the number of
     /// bytes written to the buffer.
-    fn serialize<'a>(&self, buffer: &'a mut [u8]) -> Result<&'a [u8], SerializeError>;
+    fn serialize(&self, buffer: &mut [u8]) -> Result<usize, SerializeError>;
 }
 
 impl<T> SerializeExt for T
 where
     T: Serialize,
 {
-    fn serialize<'a>(&self, buffer: &'a mut [u8]) -> Result<&'a [u8], SerializeError> {
+    fn serialize(&self, buffer: &mut [u8]) -> Result<usize, SerializeError> {
         let mut writer = ByteWriter::new(buffer);
         let written = writer.write_counted(|writer| self.serialize_partial(writer))?;
-        Ok(&buffer[..written])
+        Ok(written)
     }
 }


### PR DESCRIPTION
The docs for `SerializeExt::serialize` specify that it returns the amount of bytes written. This change brings the return-type and value in line with the documentation.