### PR TITLE
feat: implement `serialize_with_serializable` for SOME/IP `Header`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ## Veecle OS Data Support SOME/IP
 
 * **breaking** Change return type of `veecle_os_data_support_someip::serialize::SerializeExt::serialize` to match its documentation.
+* Add `serialize_with_serializable` to `veecle_os_data_support_someip::header::Header` to allow serializing without intermediate buffer.
 
 # 0.1.0
 


### PR DESCRIPTION
Allows serializing any type that implements `Serialize` without having to serialize to a separate buffer first.