### PR TITLE
feat(orchestrator): add process priority support for runtimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "slab",
  "windows-sys 0.60.2",
 ]
@@ -856,7 +856,7 @@ dependencies = [
  "crossterm_winapi",
  "document-features",
  "parking_lot",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "winapi",
 ]
 
@@ -2513,9 +2513,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -3348,7 +3348,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "windows-sys 0.60.2",
 ]
 
@@ -3700,15 +3700,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4237,7 +4237,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "windows-sys 0.61.2",
 ]
 
@@ -4783,6 +4783,7 @@ dependencies = [
  "futures",
  "libc",
  "nix 0.30.1",
+ "rustix 1.1.2",
  "serde",
  "serde_json",
  "sha2",
@@ -4820,6 +4821,7 @@ name = "veecle-orchestrator-protocol"
 version = "0.1.0"
 dependencies = [
  "camino",
+ "clap",
  "serde",
  "sha2",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ re_log = { version = "0.27.2", default-features = false }
 rfd = { version = "0.16.0", default-features = false }
 rtt-target = { version = "0.6.2", default-features = false }
 runtime-macros = { version = "1.1.1", default-features = false }
+rustix = { version = "1.1.2", default-features = false }
 scraper = { version = "0.24.0", default-features = false }
 serde = { version = "1.0.219", default-features = false }
 serde_derive = { version = "1.0.219", default-features = false }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1053,7 +1053,7 @@ version = "0.4.15"
 criteria = "safe-to-run"
 
 [[exemptions.linux-raw-sys]]
-version = "0.9.4"
+version = "0.11.0"
 criteria = "safe-to-run"
 
 [[exemptions.litemap]]
@@ -1533,7 +1533,7 @@ version = "0.38.44"
 criteria = "safe-to-run"
 
 [[exemptions.rustix]]
-version = "1.0.8"
+version = "1.1.2"
 criteria = "safe-to-run"
 
 [[exemptions.rustversion]]

--- a/veecle-ipc-protocol/src/lib.rs
+++ b/veecle-ipc-protocol/src/lib.rs
@@ -9,6 +9,19 @@ use tokio_util::codec::{Decoder, Encoder, LinesCodec, LinesCodecError};
 pub use uuid::Uuid;
 use veecle_telemetry::to_static::ToStatic;
 
+/// Priority level for a runtime process.
+#[derive(Clone, Copy, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Priority {
+    /// High priority (nice value -10).
+    High,
+    /// Normal priority (nice value 0).
+    #[default]
+    Normal,
+    /// Low priority (nice value 10).
+    Low,
+}
+
 /// A control request sent from a runtime to the orchestrator.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, veecle_os_runtime::Storable)]
 pub enum ControlRequest {
@@ -17,6 +30,12 @@ pub enum ControlRequest {
         /// The runtime instance to start.
         // This is `veecle_orchestrator_protocol::InstanceId` but we don't want the dependency.
         id: Uuid,
+
+        /// The priority level for the runtime process.
+        ///
+        /// If not specified, defaults to [`Priority::Normal`].
+        #[serde(default)]
+        priority: Option<Priority>,
     },
 
     /// Request to stop a runtime instance.

--- a/veecle-orchestrator-cli/Cargo.toml
+++ b/veecle-orchestrator-cli/Cargo.toml
@@ -22,7 +22,7 @@ itertools = { workspace = true, features = ["use_std"] }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 veecle-net-utils = { path = "../veecle-net-utils", version = "0.1.0", default-features = false }
-veecle-orchestrator-protocol = { workspace = true }
+veecle-orchestrator-protocol = { workspace = true, features = ["clap"] }
 
 [lints]
 workspace = true

--- a/veecle-orchestrator-cli/src/lib.rs
+++ b/veecle-orchestrator-cli/src/lib.rs
@@ -10,7 +10,7 @@ use comfy_table::{Cell, Color, Table};
 use itertools::Itertools;
 use serde::de::DeserializeOwned;
 use veecle_net_utils::{BlockingSocketStream, UnresolvedMultiSocketAddress};
-use veecle_orchestrator_protocol::{Info, InstanceId, LinkTarget, Request, Response};
+use veecle_orchestrator_protocol::{Info, InstanceId, LinkTarget, Priority, Request, Response};
 
 /// Veecle OS Orchestrator CLI interface
 ///
@@ -65,7 +65,13 @@ enum Runtime {
     Remove { id: InstanceId },
 
     /// Start the runtime instance with the passed id.
-    Start { id: InstanceId },
+    Start {
+        id: InstanceId,
+
+        /// Priority level for the runtime process.
+        #[arg(long)]
+        priority: Option<Priority>,
+    },
 
     /// Stop the runtime instance with the passed id.
     Stop { id: InstanceId },
@@ -191,8 +197,8 @@ impl Arguments {
                 let () = send(&mut stream, Request::Remove(id))?;
                 println!("removed instance {id}");
             }
-            Command::Runtime(Runtime::Start { id }) => {
-                let () = send(&mut stream, Request::Start(id))?;
+            Command::Runtime(Runtime::Start { id, priority }) => {
+                let () = send(&mut stream, Request::Start { id, priority })?;
                 println!("started instance {id}");
             }
             Command::Runtime(Runtime::Stop { id }) => {

--- a/veecle-orchestrator-protocol/Cargo.toml
+++ b/veecle-orchestrator-protocol/Cargo.toml
@@ -15,6 +15,7 @@ workspace-checks.miri = false
 
 [dependencies]
 camino = { workspace = true, features = ["serde1"] }
+clap = { workspace = true, features = ["derive"], optional = true }
 serde = { workspace = true, features = ["derive", "std"] }
 sha2 = { workspace = true }
 uuid = { workspace = true, features = ["serde", "std", "v7"] }

--- a/veecle-orchestrator/Cargo.toml
+++ b/veecle-orchestrator/Cargo.toml
@@ -20,6 +20,7 @@ eyre = { workspace = true }
 futures = { workspace = true, features = ["async-await", "std"] }
 libc = { workspace = true }
 nix = { workspace = true, features = ["signal"] }
+rustix = { workspace = true, features = ["process"] }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 sha2 = { workspace = true }

--- a/veecle-orchestrator/README.md
+++ b/veecle-orchestrator/README.md
@@ -40,6 +40,30 @@ stopped instance 0195fc7b-33e6-70e3-bee1-ac515185fac7
 removed instance 0195fc7b-33e6-70e3-bee1-ac515185fac7
 ```
 
+### Process Priority
+
+When starting a runtime instance, you can optionally set the process priority using the `--priority` flag.
+This controls the Linux process nice value and affects CPU scheduling priority.
+
+```console
+# Start with high priority (nice value -10)
+> cargo run -p veecle-orchestrator-cli -- runtime start --priority high <instance-id>
+
+# Start with normal priority (nice value 0, default)
+> cargo run -p veecle-orchestrator-cli -- runtime start <instance-id>
+
+# Start with low priority (nice value 10)
+> cargo run -p veecle-orchestrator-cli -- runtime start --priority low <instance-id>
+```
+
+Available priority levels:
+- `high`: Nice value -10 (higher CPU priority)
+- `normal`: Nice value 0 (default OS priority)
+- `low`: Nice value 10 (lower CPU priority)
+
+Note that setting negative nice values (high priority) requires appropriate permissions (CAP_SYS_NICE capability or sufficient RLIMIT_NICE).
+If the orchestrator lacks these permissions, a warning will be logged but the runtime will still start with the default priority.
+
 You should see logs from these actions in the orchestrator as well
 
 ```console

--- a/veecle-orchestrator/src/api.rs
+++ b/veecle-orchestrator/src/api.rs
@@ -195,8 +195,11 @@ async fn handle_request(
             conductor.remove(id).await.wrap_err("removing instance")?;
             encode(())?
         }
-        Request::Start(id) => {
-            conductor.start(id).await.wrap_err("starting instance")?;
+        Request::Start { id, priority } => {
+            conductor
+                .start(id, priority)
+                .await
+                .wrap_err("starting instance")?;
             encode(())?
         }
         Request::Stop(id) => {

--- a/veecle-orchestrator/src/runtime/conductor/state.rs
+++ b/veecle-orchestrator/src/runtime/conductor/state.rs
@@ -7,7 +7,7 @@ use eyre::{OptionExt, Result, bail};
 use futures::stream::StreamExt;
 use tempfile::TempDir;
 use tokio::sync::mpsc;
-use veecle_orchestrator_protocol::{InstanceId, RuntimeInfo};
+use veecle_orchestrator_protocol::{InstanceId, Priority, RuntimeInfo};
 
 use crate::distributor::Distributor;
 use crate::runtime::conductor::Command;
@@ -93,12 +93,16 @@ impl State {
     }
 
     #[tracing::instrument(skip(self))]
-    pub(super) fn start_instance(&mut self, id: InstanceId) -> Result<()> {
+    pub(super) fn start_instance(
+        &mut self,
+        id: InstanceId,
+        priority: Option<Priority>,
+    ) -> Result<()> {
         let Some(instance) = self.runtimes.get_mut(&id) else {
             bail!("instance id {id} was not registered");
         };
 
-        instance.start()?;
+        instance.start(priority)?;
 
         Ok(())
     }

--- a/veecle-os-examples/orchestrator-ipc/run.sh
+++ b/veecle-os-examples/orchestrator-ipc/run.sh
@@ -187,14 +187,14 @@ sleep 1
 case "$subset"
 in
   ping-pong)
-    run "$CLI" --socket "$CONTROL1" runtime start $TRACE_ID
+    run "$CLI" --socket "$CONTROL1" runtime start $TRACE_ID --priority high
     run "$CLI" --socket "$CONTROL2" runtime start $PONG_ID
-    run "$CLI" --socket "$CONTROL1" runtime start $PING_ID
+    run "$CLI" --socket "$CONTROL1" runtime start $PING_ID --priority low
   ;;
 
   useless)
-    run "$CLI" --socket "$CONTROL1" runtime start $USELESS_MACHINE1_ID
-    run "$CLI" --socket "$CONTROL2" runtime start $USELESS_MACHINE2_ID
+    run "$CLI" --socket "$CONTROL1" runtime start $USELESS_MACHINE1_ID --priority low
+    run "$CLI" --socket "$CONTROL2" runtime start $USELESS_MACHINE2_ID --priority high
   ;;
 esac
 


### PR DESCRIPTION
Add ability to set process priority (high/normal/low) for orchestrator runtime instances.
Priority is passed when starting a runtime and maps to Linux nice values for CPU scheduling control.

Changes:
- Add `Priority` enum to `veecle-orchestrator-protocol` with three levels (high=-10, normal=0, low=10 nice values)
- Modify `Request::Start` to include optional priority field
- Update orchestrator core to apply priority
- Add `--priority` flag to CLI runtime start command
- Update README with priority usage documentation
- Update orchestrator-ipc examples to demonstrate priority levels

Each runtime instance can now have its scheduling priority set independently, providing per-component priority control.

Closes: DEV-1025