### PR TITLE
feat!: defer value formatting to collectors for `no_std` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 ## Veecle Telemetry
 
+* **breaking** Telemetry protocol types (`InstanceMessage`, `TelemetryMessage`, `LogMessage`, etc.) are now generic over value types to support formatting in `no_std` environments.
+  Use `transient::*` type aliases for local telemetry operations (supports `format_args!`) and `owned::*` aliases for deserialization and cross-thread communication.
+  The `Export` trait now accepts `transient::InstanceMessage<'_>` instead of `InstanceMessage<'_>`.
 * Added `ConsolePrettyExporter` for pretty printed telemetry output for non-production use-cases.
 
 ## Veecle Telemetry VSCode Extension

--- a/docs/user-manual/crates/traces-serialization/tests/traces_serialization.rs
+++ b/docs/user-manual/crates/traces-serialization/tests/traces_serialization.rs
@@ -2,9 +2,8 @@
 fn traces_serialization_runs() {
     assert_cmd::cargo::cargo_bin_cmd!("traces-serialization")
         .assert()
-        // TODO(DEV-532): check value logged via debug format.
         .stdout(predicates::str::contains(
-            r#"{"key":"type_name","value":{"String":"traces_serialization::Pong"}}"#,
+            r#"{"key":"value","value":{"String":"5"}}"#,
         ))
         .success();
 }

--- a/veecle-ipc/src/connector.rs
+++ b/veecle-ipc/src/connector.rs
@@ -20,7 +20,7 @@ type Inputs = Arc<Mutex<HashMap<&'static str, mpsc::Sender<String>>>>;
 #[derive(Debug)]
 struct OutputTx {
     storable: mpsc::Sender<EncodedStorable>,
-    telemetry: mpsc::Sender<veecle_telemetry::protocol::InstanceMessage<'static>>,
+    telemetry: mpsc::Sender<veecle_telemetry::protocol::owned::InstanceMessage>,
     control: mpsc::Sender<ControlRequest>,
 }
 
@@ -28,7 +28,7 @@ struct OutputTx {
 #[derive(Debug)]
 struct OutputRx {
     storable: mpsc::Receiver<EncodedStorable>,
-    telemetry: mpsc::Receiver<veecle_telemetry::protocol::InstanceMessage<'static>>,
+    telemetry: mpsc::Receiver<veecle_telemetry::protocol::owned::InstanceMessage>,
     control: mpsc::Receiver<ControlRequest>,
 }
 
@@ -37,7 +37,7 @@ impl OutputRx {
     ///
     /// Purposefully prioritizes the more important channels to drain first.
     /// This may lead to the low priority channels never being serviced if we are not keeping up.
-    async fn recv(&mut self) -> Option<Message<'static>> {
+    async fn recv(&mut self) -> Option<Message> {
         Some(tokio::select! {
             biased; // Polls all branches in order to guarantee prioritization.
             Some(control) = self.control.recv() => Message::ControlRequest(control),

--- a/veecle-ipc/tests/send_policy.rs
+++ b/veecle-ipc/tests/send_policy.rs
@@ -20,7 +20,7 @@ struct TestData {
 #[tokio::test]
 #[cfg_attr(coverage_nightly, coverage(off))]
 async fn test_drop_policy_behavior() {
-    let (sender, mut receiver) = mpsc::channel::<Message<'static>>(2);
+    let (sender, mut receiver) = mpsc::channel::<Message>(2);
 
     for index in 0..2 {
         sender

--- a/veecle-os-examples/common/src/actors/time.rs
+++ b/veecle-os-examples/common/src/actors/time.rs
@@ -44,39 +44,14 @@ pub async fn ticker_reader(mut reader: InitializedReader<'_, Tick>) -> Infallibl
             .wait_for_update()
             .await
             .read(|&Tick { at: tick_at }| {
-                info!(
-                    "last tick was at",
-                    tick_at = {
-                        // TODO(DEV-532): write a formatted string without `alloc`.
-                        #[cfg(feature = "alloc")]
-                        {
-                            alloc::format!("{tick_at:?}")
-                        }
-                        #[cfg(not(feature = "alloc"))]
-                        {
-                            i64::try_from(tick_at.duration_since(Instant::MIN).unwrap().as_millis())
-                                .unwrap()
-                        }
-                    }
-                );
+                info!("last tick was at", tick_at = format_args!("{tick_at:?}"));
+
                 if let Some(previous) = previous
                     && let Some(elapsed) = tick_at.duration_since(previous)
                 {
-                    let _ = elapsed;
-                    info!(
-                        "since last tick",
-                        elapsed = {
-                            #[cfg(feature = "alloc")]
-                            {
-                                alloc::format!("{elapsed:?}")
-                            }
-                            #[cfg(not(feature = "alloc"))]
-                            {
-                                i64::try_from(elapsed.as_millis()).unwrap()
-                            }
-                        }
-                    );
+                    info!("since last tick", elapsed = format_args!("{elapsed:?}"));
                 }
+
                 if previous
                     .replace(tick_at)
                     .and_then(|previous| tick_at.duration_since(previous))

--- a/veecle-os-runtime/src/datastore/exclusive_reader.rs
+++ b/veecle-os-runtime/src/datastore/exclusive_reader.rs
@@ -79,8 +79,8 @@ where
         self.waiter.read(|value| {
             let value = value.as_ref();
 
-            // TODO(DEV-532): add debug format
-            veecle_telemetry::trace!("Slot read", type_name = self.waiter.inner_type_name());
+            veecle_telemetry::trace!("Slot read", value = format_args!("{value:?}"));
+
             f(value)
         })
     }
@@ -92,11 +92,7 @@ where
 
         let value = self.waiter.take(span.context());
 
-        // TODO(DEV-532): add debug format
-        veecle_telemetry::trace!(
-            "Slot value taken.",
-            type_name = self.waiter.inner_type_name()
-        );
+        veecle_telemetry::trace!("Slot value taken", value = format_args!("{value:?}"));
 
         value
     }

--- a/veecle-os-runtime/src/datastore/initialized_reader.rs
+++ b/veecle-os-runtime/src/datastore/initialized_reader.rs
@@ -74,8 +74,7 @@ where
                 .as_ref()
                 .expect("initialized reader should only access initialized values");
 
-            // TODO(DEV-532): add debug format
-            veecle_telemetry::trace!("Slot read", type_name = self.waiter.inner_type_name());
+            veecle_telemetry::trace!("Slot read", value = format_args!("{value:?}"));
             f(value)
         })
     }

--- a/veecle-os-runtime/src/datastore/reader.rs
+++ b/veecle-os-runtime/src/datastore/reader.rs
@@ -85,8 +85,7 @@ where
         self.waiter.read(|value| {
             let value = value.as_ref();
 
-            // TODO(DEV-532): add debug format
-            veecle_telemetry::trace!("Slot read", type_name = self.waiter.inner_type_name());
+            veecle_telemetry::trace!("Slot read", value = format_args!("{value:?}"));
             f(value)
         })
     }

--- a/veecle-os-runtime/src/datastore/slot/waiter.rs
+++ b/veecle-os-runtime/src/datastore/slot/waiter.rs
@@ -44,10 +44,6 @@ where
         self.slot.read(f)
     }
 
-    pub(crate) fn inner_type_name(&self) -> &'static str {
-        self.slot.inner_type_name()
-    }
-
     pub(crate) async fn wait(&self) {
         if let Err(generational::MissedUpdate { current, expected }) = self.waiter.wait().await {
             // While we are unsure about timing and such, I would at least keep a warning

--- a/veecle-os-runtime/src/datastore/writer.rs
+++ b/veecle-os-runtime/src/datastore/writer.rs
@@ -129,14 +129,11 @@ where
             self.ready().await;
             self.waiter.update_generation();
 
-            let type_name = self.slot.inner_type_name();
-
             self.slot.modify(
                 |value| {
                     f(value);
 
-                    // TODO(DEV-532): add debug format
-                    veecle_telemetry::trace!("Slot modified", type_name);
+                    veecle_telemetry::trace!("Slot modified", value = format_args!("{value:?}"));
                 },
                 span_context,
             );
@@ -151,11 +148,11 @@ where
     /// This method takes a closure to ensure the reference is not held across await points.
     #[veecle_telemetry::instrument]
     pub fn read<U>(&self, f: impl FnOnce(Option<&T::DataType>) -> U) -> U {
-        let type_name = self.slot.inner_type_name();
         self.slot.read(|value| {
             let value = value.as_ref();
-            // TODO(DEV-532): add debug format
-            veecle_telemetry::trace!("Slot read", type_name);
+
+            veecle_telemetry::trace!("Slot read", value = format_args!("{value:?}"));
+
             f(value)
         })
     }

--- a/veecle-telemetry/src/collector/json_exporter.rs
+++ b/veecle-telemetry/src/collector/json_exporter.rs
@@ -1,5 +1,4 @@
 use super::Export;
-use crate::protocol::InstanceMessage;
 
 /// An exporter that outputs telemetry messages as JSON to stdout.
 ///
@@ -20,7 +19,7 @@ impl ConsoleJsonExporter {
 }
 
 impl Export for ConsoleJsonExporter {
-    fn export(&self, message: InstanceMessage) {
+    fn export(&self, message: crate::protocol::transient::InstanceMessage) {
         std::println!("{}", serde_json::to_string(&message).unwrap());
     }
 }

--- a/veecle-telemetry/src/collector/pretty_exporter.rs
+++ b/veecle-telemetry/src/collector/pretty_exporter.rs
@@ -1,5 +1,5 @@
 use super::Export;
-use crate::protocol::{InstanceMessage, LogMessage, TelemetryMessage};
+use crate::protocol::transient::{InstanceMessage, LogMessage, TelemetryMessage};
 use std::string::String;
 
 /// Exporter that pretty prints telemetry messages to stderr.
@@ -84,7 +84,8 @@ fn format_message(message: TelemetryMessage, mut output: impl std::io::Write) {
 mod tests {
     use super::format_message;
     use crate::macros::attributes;
-    use crate::protocol::{LogMessage, Severity, TelemetryMessage};
+    use crate::protocol::Severity;
+    use crate::protocol::transient::{LogMessage, TelemetryMessage};
     use indoc::indoc;
     use pretty_assertions::assert_eq;
     use std::vec::Vec;

--- a/veecle-telemetry/src/collector/test_exporter.rs
+++ b/veecle-telemetry/src/collector/test_exporter.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 use std::vec::Vec;
 
 use super::Export;
-use crate::protocol::InstanceMessage;
+use crate::protocol::owned;
 use crate::to_static::ToStatic;
 
 /// An exporter for testing that stores all telemetry messages in memory.
@@ -12,7 +12,7 @@ use crate::to_static::ToStatic;
 #[derive(Debug)]
 pub struct TestExporter {
     /// Shared vector storing all exported telemetry messages
-    pub spans: Arc<Mutex<Vec<InstanceMessage<'static>>>>,
+    pub spans: Arc<Mutex<Vec<owned::InstanceMessage>>>,
 }
 
 impl TestExporter {
@@ -30,7 +30,7 @@ impl TestExporter {
     /// // Use exporter for telemetry collection
     /// // Check messages for verification
     /// ```
-    pub fn new() -> (Self, Arc<Mutex<Vec<InstanceMessage<'static>>>>) {
+    pub fn new() -> (Self, Arc<Mutex<Vec<owned::InstanceMessage>>>) {
         let spans = Arc::new(Mutex::new(Vec::new()));
         (
             Self {
@@ -42,7 +42,7 @@ impl TestExporter {
 }
 
 impl Export for TestExporter {
-    fn export(&self, message: InstanceMessage<'_>) {
+    fn export(&self, message: crate::protocol::transient::InstanceMessage<'_>) {
         self.spans.lock().unwrap().push(message.to_static());
     }
 }

--- a/veecle-telemetry/src/lib.rs
+++ b/veecle-telemetry/src/lib.rs
@@ -113,5 +113,7 @@ pub mod value;
 
 pub use id::{ProcessId, SpanContext, SpanId};
 pub use span::{CurrentSpan, Span, SpanGuard, SpanGuardRef};
-pub use value::{KeyValue, Value};
+#[cfg(feature = "alloc")]
+pub use value::OwnedValue;
+pub use value::{KeyValue, TransientValue};
 pub use veecle_telemetry_macros::instrument;

--- a/veecle-telemetry/src/log.rs
+++ b/veecle-telemetry/src/log.rs
@@ -23,10 +23,10 @@
 //! });
 //! ```
 
-use crate::KeyValue;
 #[cfg(feature = "enable")]
 use crate::collector::get_collector;
 use crate::protocol::Severity;
+use crate::protocol::transient;
 #[cfg(feature = "enable")]
 use crate::protocol::{LogMessage, attribute_list_from_slice};
 #[cfg(feature = "enable")]
@@ -52,7 +52,7 @@ use crate::time::now;
 /// ```rust
 /// use veecle_telemetry::log::log;
 /// use veecle_telemetry::protocol::Severity;
-/// use veecle_telemetry::{KeyValue, Value, span};
+/// use veecle_telemetry::{KeyValue, TransientValue, span};
 ///
 /// // Simple log message
 /// log(Severity::Info, "Server started", &[]);
@@ -74,7 +74,7 @@ use crate::time::now;
 /// When the `enable` feature is disabled, this function compiles to a no-op
 /// and has zero runtime overhead.
 #[doc(hidden)]
-pub fn log(severity: Severity, body: &'static str, attributes: &'_ [KeyValue<'static>]) {
+pub fn log(severity: Severity, body: &str, attributes: &'_ [transient::KeyValue<'_>]) {
     #[cfg(not(feature = "enable"))]
     {
         let _ = (severity, body, attributes);

--- a/veecle-telemetry/src/macros.rs
+++ b/veecle-telemetry/src/macros.rs
@@ -360,9 +360,9 @@ macro_rules! fatal {
 /// Empty attributes:
 /// ```rust
 /// use veecle_telemetry::attributes;
-/// use veecle_telemetry::value::KeyValue;
+/// use veecle_telemetry::protocol::transient;
 ///
-/// let attrs: &[KeyValue] = attributes!(); // Creates an empty slice
+/// let attrs: &[transient::KeyValue<'_>] = attributes!(); // Creates an empty slice
 /// ```
 #[macro_export]
 macro_rules! attributes {

--- a/veecle-telemetry/src/to_static.rs
+++ b/veecle-telemetry/src/to_static.rs
@@ -22,7 +22,7 @@ use alloc::borrow::Cow;
 /// A trait for converting types with lifetime parameters to equivalent types with 'static lifetime.
 pub trait ToStatic: Clone {
     /// The same type but with 'static lifetime and owned data.
-    type Static: 'static + Clone + Send + Sync;
+    type Static: 'static + Clone;
 
     /// Converts this type to the equivalent type with 'static lifetime.
     ///

--- a/veecle-telemetry/src/value.rs
+++ b/veecle-telemetry/src/value.rs
@@ -6,8 +6,9 @@
 //!
 //! # Value Types
 //!
-//! The [`Value`] enum supports common data types:
+//! The [`TransientValue`] enum supports common data types:
 //! - **String**: Text values (adapted to platform string type)
+//! - **Formatted**: Lazy format arguments (for `no_std` environments)
 //! - **Bool**: Boolean values (true/false)
 //! - **I64**: 64-bit signed integers
 //! - **F64**: 64-bit floating-point numbers
@@ -16,7 +17,7 @@
 //!
 //! ```rust
 //! use veecle_telemetry::types::StringType;
-//! use veecle_telemetry::{KeyValue, Value};
+//! use veecle_telemetry::{KeyValue, TransientValue};
 //!
 //! // Create key-value pairs
 //! let user_id = KeyValue::new("user_id", 123);
@@ -25,10 +26,10 @@
 //! let score = KeyValue::new("score", 95.5);
 //!
 //! // Values can be created from various types
-//! let string_value = Value::String("hello".into());
-//! let int_value = Value::I64(42);
-//! let bool_value = Value::Bool(true);
-//! let float_value = Value::F64(3.14);
+//! let string_value = TransientValue::String("hello".into());
+//! let int_value = TransientValue::I64(42);
+//! let bool_value = TransientValue::Bool(true);
+//! let float_value = TransientValue::F64(3.14);
 //! ```
 
 use serde::{Deserialize, Serialize};
@@ -47,7 +48,7 @@ use crate::types::StringType;
 ///
 /// ```rust
 /// use veecle_telemetry::types::StringType;
-/// use veecle_telemetry::{KeyValue, Value};
+/// use veecle_telemetry::{KeyValue, TransientValue};
 ///
 /// // Create attributes with different value types
 /// let user_id = KeyValue::new("user_id", 123);
@@ -56,16 +57,16 @@ use crate::types::StringType;
 /// let score = KeyValue::new("score", 95.5);
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct KeyValue<'a> {
+pub struct KeyValue<'a, V> {
     /// The attribute key (name)
     #[serde(borrow)]
     pub key: StringType<'a>,
+
     /// The attribute value
-    #[serde(borrow)]
-    pub value: Value<'a>,
+    pub value: V,
 }
 
-impl<'a> KeyValue<'a> {
+impl<'a> KeyValue<'a, TransientValue<'a>> {
     /// Creates a new key-value attribute pair.
     ///
     /// # Arguments
@@ -84,7 +85,7 @@ impl<'a> KeyValue<'a> {
     pub fn new<K, V>(key: K, value: V) -> Self
     where
         K: Into<StringType<'a>>,
-        V: Into<Value<'a>>,
+        V: Into<TransientValue<'a>>,
     {
         Self {
             key: key.into(),
@@ -93,15 +94,21 @@ impl<'a> KeyValue<'a> {
     }
 }
 
-impl core::fmt::Display for KeyValue<'_> {
+impl<V> core::fmt::Display for KeyValue<'_, V>
+where
+    V: core::fmt::Display,
+{
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}: {}", self.key, self.value)
     }
 }
 
 #[cfg(feature = "alloc")]
-impl ToStatic for KeyValue<'_> {
-    type Static = KeyValue<'static>;
+impl<V> ToStatic for KeyValue<'_, V>
+where
+    V: ToStatic,
+{
+    type Static = KeyValue<'static, V::Static>;
 
     fn to_static(&self) -> Self::Static {
         KeyValue {
@@ -111,109 +118,197 @@ impl ToStatic for KeyValue<'_> {
     }
 }
 
-/// A value that can be stored in a telemetry attribute.
+/// A transient value that can be stored in a telemetry attribute.
 ///
-/// This enum represents the different types of values that can be associated
+/// This enum represents values that may contain non-Send types like `format_args!`,
+/// making them suitable for local use but not for sending across threads.
+/// Use [`OwnedValue`] for values that need to cross thread boundaries.
 ///
 /// # Examples
 ///
 /// ```rust
-/// use veecle_telemetry::Value;
+/// use veecle_telemetry::TransientValue;
 ///
 /// // Create values of different types
-/// let text = Value::String("hello world".into());
-/// let number = Value::I64(42);
-/// let flag = Value::Bool(true);
-/// let rating = Value::F64(4.5);
+/// let text = TransientValue::String("hello world".into());
+/// let number = TransientValue::I64(42);
+/// let flag = TransientValue::Bool(true);
+/// let rating = TransientValue::F64(4.5);
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum Value<'a> {
+pub enum TransientValue<'a> {
     /// A string value (adapted to platform string type)
     String(#[serde(borrow)] StringType<'a>),
+
+    /// A `format_args!` call.
+    #[serde(rename(serialize = "String"))]
+    #[serde(skip_deserializing)]
+    Formatted(core::fmt::Arguments<'a>),
+
     /// A boolean value
     Bool(bool),
+
     /// A 64-bit signed integer
     I64(i64),
+
     /// A 64-bit floating-point number
     F64(f64),
 }
 
 #[cfg(feature = "alloc")]
-impl ToStatic for Value<'_> {
-    type Static = Value<'static>;
+impl ToStatic for TransientValue<'_> {
+    type Static = OwnedValue;
 
     fn to_static(&self) -> Self::Static {
+        use alloc::string::ToString;
+
         match self {
-            Value::String(s) => Value::String(s.clone().into_owned().into()),
-            Value::Bool(b) => Value::Bool(*b),
-            Value::I64(i) => Value::I64(*i),
-            Value::F64(f) => Value::F64(*f),
+            Self::String(s) => OwnedValue::String(s.clone().into_owned()),
+            Self::Formatted(s) => OwnedValue::String(s.to_string()),
+            Self::Bool(b) => OwnedValue::Bool(*b),
+            Self::I64(i) => OwnedValue::I64(*i),
+            Self::F64(f) => OwnedValue::F64(*f),
         }
     }
 }
 
-impl<'a> core::fmt::Display for Value<'a> {
+impl<'a> core::fmt::Display for TransientValue<'a> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             // For strings, debug print so they will get delimiters, since we are explicitly
             // representing strings rather than directly human-targeted text, and they will be used
             // in situations where knowing where the string ends is important.
-            Value::String(value) => write!(f, "{value:?}"),
-            Value::Bool(value) => write!(f, "{value}"),
-            Value::I64(value) => write!(f, "{value}"),
-            Value::F64(value) => write!(f, "{value}"),
+            Self::String(value) => write!(f, "{value:?}"),
+            Self::Formatted(value) => write!(f, "{value:?}"),
+            Self::Bool(value) => write!(f, "{value}"),
+            Self::I64(value) => write!(f, "{value}"),
+            Self::F64(value) => write!(f, "{value}"),
         }
     }
 }
 
 #[cfg(feature = "alloc")]
-impl<'a> From<alloc::borrow::Cow<'a, str>> for Value<'a> {
+impl<'a> From<alloc::borrow::Cow<'a, str>> for TransientValue<'a> {
     fn from(value: alloc::borrow::Cow<'a, str>) -> Self {
-        Value::String(value)
+        TransientValue::String(value)
     }
 }
 
 #[cfg(feature = "alloc")]
-impl<'a> From<alloc::string::String> for Value<'a> {
+impl<'a> From<alloc::string::String> for TransientValue<'a> {
     fn from(value: alloc::string::String) -> Self {
-        Value::String(value.into())
+        TransientValue::String(value.into())
     }
 }
 
 #[cfg(feature = "alloc")]
-impl<'a> From<&'a alloc::string::String> for Value<'a> {
+impl<'a> From<&'a alloc::string::String> for TransientValue<'a> {
     fn from(value: &'a alloc::string::String) -> Self {
-        Value::String(value.into())
+        TransientValue::String(value.into())
     }
 }
 
-impl<'a> From<&'a str> for Value<'a> {
+impl<'a> From<&'a str> for TransientValue<'a> {
     fn from(value: &'a str) -> Self {
         #[cfg(feature = "alloc")]
         {
-            Value::String(alloc::borrow::Cow::Borrowed(value))
+            TransientValue::String(alloc::borrow::Cow::Borrowed(value))
         }
         #[cfg(not(feature = "alloc"))]
         {
-            Value::String(value)
+            TransientValue::String(value)
         }
     }
 }
 
-impl From<bool> for Value<'_> {
+impl<'a> From<core::fmt::Arguments<'a>> for TransientValue<'a> {
+    fn from(value: core::fmt::Arguments<'a>) -> Self {
+        TransientValue::Formatted(value)
+    }
+}
+
+impl From<bool> for TransientValue<'_> {
     fn from(value: bool) -> Self {
-        Value::Bool(value)
+        TransientValue::Bool(value)
     }
 }
 
-impl From<i64> for Value<'_> {
+impl From<i64> for TransientValue<'_> {
     fn from(value: i64) -> Self {
-        Value::I64(value)
+        TransientValue::I64(value)
     }
 }
 
-impl From<f64> for Value<'_> {
+impl From<f64> for TransientValue<'_> {
     fn from(value: f64) -> Self {
-        Value::F64(value)
+        TransientValue::F64(value)
+    }
+}
+
+/// An owned value that can be sent across thread boundaries.
+///
+/// Unlike [`TransientValue`], this type is fully owned and does not contain
+/// any non-Send types like `format_args!`. This makes it suitable for
+/// serialization and sending across threads via channels.
+///
+/// Cross-serialization compatible with [`TransientValue`] - the transient
+/// variants will be converted to owned types during serialization.
+///
+/// # Examples
+///
+/// ```rust
+/// use veecle_telemetry::{OwnedValue, TransientValue};
+///
+/// // Create a TransientValue with format_args!
+/// let count = 42;
+/// let transient = TransientValue::Formatted(format_args!("count: {count}"));
+///
+/// // Serialize to JSON
+/// let json = serde_json::to_string(&transient)?;
+/// assert_eq!(json, r#"{"String":"count: 42"}"#);
+///
+/// // Deserialize as OwnedValue
+/// let owned: OwnedValue = serde_json::from_str(&json)?;
+/// let OwnedValue::String(string) = owned else { panic!("unexpected variant") };
+/// assert_eq!(string, "count: 42");
+/// # Ok::<(), serde_json::Error>(())
+/// ```
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg(feature = "alloc")]
+pub enum OwnedValue {
+    /// A string value (owned)
+    String(alloc::string::String),
+
+    /// A boolean value
+    Bool(bool),
+
+    /// A 64-bit signed integer
+    I64(i64),
+
+    /// A 64-bit floating-point number
+    F64(f64),
+}
+
+#[cfg(feature = "alloc")]
+impl ToStatic for OwnedValue {
+    type Static = OwnedValue;
+
+    fn to_static(&self) -> Self::Static {
+        self.clone()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl core::fmt::Display for OwnedValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            // For strings, debug print so they will get delimiters, since we are explicitly
+            // representing strings rather than directly human-targeted text, and they will be used
+            // in situations where knowing where the string ends is important.
+            Self::String(value) => write!(f, "{value:?}"),
+            Self::Bool(value) => write!(f, "{value}"),
+            Self::I64(value) => write!(f, "{value}"),
+            Self::F64(value) => write!(f, "{value}"),
+        }
     }
 }


### PR DESCRIPTION
Telemetry attribute values are now generic, allowing collectors to decide how to handle formatting. In `no_std` environments, collectors can format values directly without requiring `alloc`. In `std` environments, collectors can accept `format_args!` to defer string allocation until export time (e.g. `serde_json` will write these directly to the output buffer).

fixes #137 