### PR TITLE
ci: update cargo-deny version

### DIFF
--- a/.github/actions/setup-tools/action.yaml
+++ b/.github/actions/setup-tools/action.yaml
@@ -60,11 +60,11 @@ runs:
       id: cache-cargo-deny
       with:
         path: ~/.cargo/bin/cargo-deny
-        key: cargo-deny-0.18.4-${{ runner.os }}-${{ runner.arch }}
+        key: cargo-deny-0.18.9-${{ runner.os }}-${{ runner.arch }}
     - shell: bash
       if: inputs.cargo-deny == 'true' && steps.cache-cargo-deny.outputs.cache-hit != 'true'
       run: |
-        cargo install cargo-deny --version 0.18.4 --locked
+        cargo install cargo-deny --version 0.18.9 --locked
 
     # Cache and install cargo-llvm-cov
     - uses: actions/cache@v4


### PR DESCRIPTION
We're hitting https://github.com/EmbarkStudios/cargo-deny/issues/804 in CI, which is fixed in the latest version of `cargo-deny`.