### PR TITLE
chore: remove unneeded ignored advisories and audits

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,9 +21,3 @@ allow = ["Unicode-DFS-2016"]
 [[licenses.exceptions]]
 crate = "slotmap"
 allow = ["Zlib"]
-
-[advisories]
-ignore = [
-  { id = "RUSTSEC-2024-0436", reason = "there aren't known vulnerabilities, we only use it in a dev-dependency, and we don't actually use the codepaths that use it" },
-  { id = "RUSTSEC-2025-0057", reason = "no known issues, just unmaintained, and we only use it in internal repo tooling, blocked on https://github.com/servo/stylo/issues/237" },
-]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -12,9 +12,3 @@ who = "Wim Looman <wim.looman@veecle.io>"
 criteria = "safe-to-run"
 version = "0.2.2"
 notes = "Very brief audit just to verify it doesn't do anything outside using proc-macro APIs."
-
-[[audits.paste]]
-who = "Wim Looman <wim.looman@veecle.io>"
-criteria = "safe-to-deploy"
-violation = "*"
-notes = "We ignore the unmaintained advisory as we use it as a dev-dependency, but don't want it to become a real dependency"


### PR DESCRIPTION
`paste` isn't used in our repo anymore, so we can remove the audit and the advisory. The second ignored advisory is for `fxhash`, which we also don't use anymore.