### PR TITLE
chore: fix compatibility with cmake 4.0+

### DIFF
--- a/capicxx-someip-sys/build.rs
+++ b/capicxx-someip-sys/build.rs
@@ -26,6 +26,7 @@ fn build_cmake_projects(paths: Vec<PathBuf>) -> anyhow::Result<()> {
         let prefix_path = format!("-DCMAKE_PREFIX_PATH={}", env_var("OUT_DIR")?);
         let install_path = cmake::Config::new(project_path)
             .configure_arg(prefix_path)
+            .configure_arg("-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
             .build();
 
         let install_lib_path = format!("{}/lib", install_path.display());

--- a/someip-test-service-sys/build.rs
+++ b/someip-test-service-sys/build.rs
@@ -46,6 +46,7 @@ fn build_cmake_project(project_path: PathBuf) -> anyhow::Result<()> {
     let prefix_path = format!("-DCMAKE_PREFIX_PATH={capicxx_someip_install_path}");
     let install_path = cmake::Config::new(project_path)
         .configure_arg(prefix_path)
+        .configure_arg("-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
         .build();
     let install_lib_path = format!("{}/lib", install_path.display());
     println!("cargo:rustc-link-search=native={install_lib_path}");


### PR DESCRIPTION
I've just been ignoring this error since updating to NixOS 25.11, but it was a simpler fix than I expected:

```
  CMake Error at CMakeLists.txt:6 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.

    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.

    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```