### PR TITLE
refactor!: replace `Infallible` with custom `Never` enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Veecle OS
 
+* **breaking** Replaced `core::convert::Infallible` with custom `Never` enum for actor return types.
+  * All actors using `Result<Infallible, E>` must change to `Result<Never, E>`.
+  * All actors using bare `Infallible` must change to bare `Never`.
+  * Import `Never` from `veecle_os::runtime::Never` or `veecle_os_runtime::Never`.
 * **breaking** The `Storable` macro no longer takes a `data_type` attribute.
   * `#[storable(data_type = "Type")] struct MyType;` becomes `impl Storable for MyType { type DataType = Type; }`.
 * **breaking** The `Storable` macro now requires a crate path without quotes.

--- a/docs/user-manual/crates/getting-started/src/main.rs
+++ b/docs/user-manual/crates/getting-started/src/main.rs
@@ -1,10 +1,9 @@
 // ANCHOR: full
 // ANCHOR: init
 //! Getting started example.
-use core::convert::Infallible;
 use core::fmt::Debug;
 
-use veecle_os::runtime::{InitializedReader, Storable, Writer};
+use veecle_os::runtime::{InitializedReader, Never, Storable, Writer};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Value;
@@ -17,7 +16,7 @@ impl Storable for Value {
 // ANCHOR: sender
 /// An actor that writes `Value { i++ }` continuously.
 #[veecle_os::runtime::actor]
-async fn sender_actor(mut writer: Writer<'_, Value>) -> Infallible {
+async fn sender_actor(mut writer: Writer<'_, Value>) -> Never {
     let mut value = 0;
     loop {
         println!("[sender] Sending {:?}", value);
@@ -30,7 +29,7 @@ async fn sender_actor(mut writer: Writer<'_, Value>) -> Infallible {
 // ANCHOR: receiver
 /// An actor that reads `Value` and terminates when the value is 5.
 #[veecle_os::runtime::actor]
-async fn receiver_actor(mut reader: InitializedReader<'_, Value>) -> Infallible {
+async fn receiver_actor(mut reader: InitializedReader<'_, Value>) -> Never {
     loop {
         println!("[receiver] Waiting for value");
         reader.wait_for_update().await.read(|value| {

--- a/docs/user-manual/crates/traces-serialization/src/main.rs
+++ b/docs/user-manual/crates/traces-serialization/src/main.rs
@@ -1,8 +1,7 @@
 // ANCHOR: full
-use core::convert::Infallible;
 use core::fmt::Debug;
 
-use veecle_os::runtime::{InitializedReader, Reader, Storable, Writer};
+use veecle_os::runtime::{InitializedReader, Never, Reader, Storable, Writer};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Ping;
@@ -19,7 +18,7 @@ impl Storable for Pong {
 }
 
 #[veecle_os::runtime::actor]
-async fn ping_actor(mut ping: Writer<'_, Ping>, pong: Reader<'_, Pong>) -> Infallible {
+async fn ping_actor(mut ping: Writer<'_, Ping>, pong: Reader<'_, Pong>) -> Never {
     let mut value = 0;
 
     ping.write(value).await;
@@ -41,10 +40,7 @@ async fn ping_actor(mut ping: Writer<'_, Ping>, pong: Reader<'_, Pong>) -> Infal
 }
 
 #[veecle_os::runtime::actor]
-async fn pong_actor(
-    mut pong: Writer<'_, Pong>,
-    mut ping: InitializedReader<'_, Ping>,
-) -> Infallible {
+async fn pong_actor(mut pong: Writer<'_, Pong>, mut ping: InitializedReader<'_, Ping>) -> Never {
     loop {
         let value = ping.wait_for_update().await.read(|ping| ping + 1);
 

--- a/veecle-ipc/src/actors/control.rs
+++ b/veecle-ipc/src/actors/control.rs
@@ -1,7 +1,5 @@
-use core::convert::Infallible;
-
 use futures::future::join;
-use veecle_os_runtime::{Reader, Writer};
+use veecle_os_runtime::{Never, Reader, Writer};
 
 use crate::{Connector, ControlRequest, ControlResponse};
 
@@ -12,10 +10,10 @@ pub async fn control_handler(
     #[init_context] connector: &Connector,
     requests: Reader<'_, ControlRequest>,
     mut responses: Writer<'_, ControlResponse>,
-) -> Infallible {
+) -> Never {
     let (output, mut input) = connector.control_channels();
 
-    let result: (Infallible, Infallible) = join(
+    let result: (Never, Never) = join(
         async move {
             let mut requests = requests.wait_init().await;
             loop {

--- a/veecle-ipc/src/actors/input.rs
+++ b/veecle-ipc/src/actors/input.rs
@@ -1,16 +1,11 @@
-use core::convert::Infallible;
-
 use serde::de::DeserializeOwned;
-use veecle_os_runtime::{Storable, Writer};
+use veecle_os_runtime::{Never, Storable, Writer};
 
 use crate::Connector;
 
 /// An actor that will receive values of type `T` from the provided [`Connector`] and send them to other actors.
 #[veecle_os_runtime::actor]
-pub async fn input<T>(
-    #[init_context] connector: &Connector,
-    mut writer: Writer<'_, T>,
-) -> Infallible
+pub async fn input<T>(#[init_context] connector: &Connector, mut writer: Writer<'_, T>) -> Never
 where
     T: Storable<DataType: DeserializeOwned> + 'static,
 {

--- a/veecle-ipc/src/actors/output.rs
+++ b/veecle-ipc/src/actors/output.rs
@@ -1,8 +1,6 @@
-use core::convert::Infallible;
-
 use serde::Serialize;
 use veecle_ipc_protocol::EncodedStorable;
-use veecle_os_runtime::{InitializedReader, Storable};
+use veecle_os_runtime::{InitializedReader, Never, Storable};
 
 use crate::{Connector, SendPolicy};
 
@@ -48,7 +46,7 @@ use crate::{Connector, SendPolicy};
 pub async fn output<T>(
     #[init_context] config: OutputConfig<'_>,
     mut reader: InitializedReader<'_, T>,
-) -> Infallible
+) -> Never
 where
     T: Storable<DataType: Serialize> + 'static,
 {

--- a/veecle-ipc/src/lib.rs
+++ b/veecle-ipc/src/lib.rs
@@ -10,9 +10,7 @@
 //!
 //! ```no_run
 //! # fn main() {
-//! use core::convert::Infallible;
-//!
-//! use veecle_os_runtime::{InitializedReader, Storable, Writer};
+//! use veecle_os_runtime::{InitializedReader, Storable, Writer, Never};
 //!
 //! #[derive(Copy, Clone, Debug, Storable, serde::Deserialize)]
 //! pub struct Ping(u8);
@@ -24,7 +22,7 @@
 //! async fn local_actor(
 //!     mut ping: InitializedReader<'_, Ping>,
 //!     mut pong: Writer<'_, Pong>,
-//! ) -> Infallible {
+//! ) -> Never {
 //!     loop {
 //!         let Ping(value) = ping.wait_for_update().await.read_cloned();
 //!         pong.write(Pong(value)).await;

--- a/veecle-os-data-support-can-codegen/src/generate/actors.rs
+++ b/veecle-os-data-support-can-codegen/src/generate/actors.rs
@@ -39,7 +39,7 @@ pub(super) fn generate(options: &crate::Options, dbc: &Dbc) -> Result<TokenStrea
             #(
                 mut #writer_names: #veecle_os_runtime::Writer<'_, #message_names>,
             )*
-        ) -> core::convert::Infallible {
+        ) -> #veecle_os_runtime::Never {
             loop {
                 let frame = reader.wait_for_update().await.read_cloned();
                 match frame.id() {

--- a/veecle-os-data-support-can-codegen/tests/cases/CSS-Electronics-SAE-J1939-DEMO.rs
+++ b/veecle-os-data-support-can-codegen/tests/cases/CSS-Electronics-SAE-J1939-DEMO.rs
@@ -307,7 +307,7 @@ pub async fn deserialize_frames(
     mut reader: ::my_veecle_os_runtime::InitializedReader<'_, Frame>,
     mut eec1_writer: ::my_veecle_os_runtime::Writer<'_, Eec1>,
     mut ccvs1_writer: ::my_veecle_os_runtime::Writer<'_, Ccvs1>,
-) -> core::convert::Infallible {
+) -> ::my_veecle_os_runtime::Never {
     loop {
         let frame = reader.wait_for_update().await.read_cloned();
         match frame.id() {

--- a/veecle-os-data-support-someip/tests/move_between_actors.rs
+++ b/veecle-os-data-support-someip/tests/move_between_actors.rs
@@ -1,10 +1,10 @@
 //! Tests whether a deserialized payload can be moved between actors without copy.
 
-use std::convert::Infallible;
 use veecle_os_data_support_someip::header::*;
 use veecle_os_data_support_someip::parse::ParseExt;
 use veecle_os_data_support_someip::service_discovery;
 use veecle_os_data_support_someip::service_discovery::{Entry, ServiceEntry};
+use veecle_os_runtime::Never;
 use veecle_os_runtime::actor;
 use veecle_os_runtime::memory_pool::{Chunk, MemoryPool};
 use veecle_os_runtime::{ExclusiveReader, Storable, Writer};
@@ -44,7 +44,7 @@ fn yoke() {
     async fn deserializer(
         mut input: ExclusiveReader<'_, Input>,
         mut writer: Writer<'_, Output>,
-    ) -> Infallible {
+    ) -> Never {
         loop {
             input.wait_for_update().await;
             let Some(bytes) = input.take() else { continue };

--- a/veecle-os-examples/common/src/actors/alloc.rs
+++ b/veecle-os-examples/common/src/actors/alloc.rs
@@ -2,11 +2,11 @@
 
 use alloc::boxed::Box;
 use alloc::format;
-use core::convert::Infallible;
 use veecle_os::osal::api::time::{Duration, TimeAbstraction};
+use veecle_os::runtime::Never;
 
 #[veecle_os::runtime::actor]
-pub async fn box_actor<T: TimeAbstraction>() -> Infallible {
+pub async fn box_actor<T: TimeAbstraction>() -> Never {
     const BOX_COUNT: usize = 5;
     let mut box_counter = 0;
     let mut boxes: [Option<Box<u64>>; BOX_COUNT] = [const { None }; BOX_COUNT];

--- a/veecle-os-examples/common/src/actors/ping_pong.rs
+++ b/veecle-os-examples/common/src/actors/ping_pong.rs
@@ -1,10 +1,9 @@
 //! Ping-pong example actors.
 
-use core::convert::Infallible;
 use core::fmt::Debug;
 use futures::future::FutureExt;
 use serde::{Deserialize, Serialize};
-use veecle_os::runtime::{InitializedReader, Reader, Storable, Writer};
+use veecle_os::runtime::{InitializedReader, Never, Reader, Storable, Writer};
 use veecle_os::telemetry::{error, info};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Storable, Deserialize, Serialize)]
@@ -20,7 +19,7 @@ pub struct Pong {
 /// An actor that writes `Ping { i }` and waits for `Pong`.
 /// Additionally, it validates that `Pong { value == i + 1 }` for `i = 0..`.
 #[veecle_os::runtime::actor]
-pub async fn ping_actor(mut ping: Writer<'_, Ping>, pong: Reader<'_, Pong>) -> Infallible {
+pub async fn ping_actor(mut ping: Writer<'_, Ping>, pong: Reader<'_, Pong>) -> Never {
     let mut value = 0;
     info!("[PING TASK] Sending initial", ping = i64::from(value));
     ping.write(Ping { value }).await;
@@ -45,7 +44,7 @@ pub async fn ping_actor(mut ping: Writer<'_, Ping>, pong: Reader<'_, Pong>) -> I
 pub async fn pong_actor(
     mut pong: Writer<'_, Pong>,
     mut ping: InitializedReader<'_, Ping>,
-) -> Infallible {
+) -> Never {
     loop {
         info!("[PONG TASK] Waiting for ping");
 
@@ -65,7 +64,7 @@ pub async fn pong_actor(
 pub async fn trace_actor(
     mut ping_reader: Reader<'_, Ping>,
     mut pong_reader: Reader<'_, Pong>,
-) -> Infallible {
+) -> Never {
     loop {
         futures::select_biased! {
             _ = ping_reader.wait_for_update().fuse() => {

--- a/veecle-os-examples/common/src/actors/tcp.rs
+++ b/veecle-os-examples/common/src/actors/tcp.rs
@@ -1,10 +1,10 @@
-use core::convert::Infallible;
 use core::net::SocketAddr;
 use embedded_io_async::{Read, Write};
 use veecle_os::osal::api::net::tcp::TcpConnection;
+use veecle_os::runtime::Never;
 
 #[veecle_os::runtime::actor]
-pub async fn tcp_server_actor<S, L>(#[init_context] input: (S, SocketAddr)) -> Infallible
+pub async fn tcp_server_actor<S, L>(#[init_context] input: (S, SocketAddr)) -> Never
 where
     S: veecle_os::osal::api::net::tcp::TcpSocket,
     L: veecle_os::osal::api::log::LogTarget,
@@ -77,7 +77,7 @@ where
 }
 
 #[veecle_os::runtime::actor]
-pub async fn tcp_client_actor<S, L>(#[init_context] input: (S, SocketAddr)) -> Infallible
+pub async fn tcp_client_actor<S, L>(#[init_context] input: (S, SocketAddr)) -> Never
 where
     S: veecle_os::osal::api::net::tcp::TcpSocket,
     L: veecle_os::osal::api::log::LogTarget,

--- a/veecle-os-examples/common/src/actors/time.rs
+++ b/veecle-os-examples/common/src/actors/time.rs
@@ -1,10 +1,9 @@
 //! A minimal example using the time abstraction.
 
-use core::convert::Infallible;
 use core::fmt::Debug;
 
 use veecle_os::osal::api::time::{Duration, Instant, Interval, TimeAbstraction};
-use veecle_os::runtime::{InitializedReader, Storable, Writer};
+use veecle_os::runtime::{InitializedReader, Never, Storable, Writer};
 use veecle_os::telemetry::{error, info};
 
 const INTERVAL_PERIOD: Duration = Duration::from_secs(1);
@@ -20,7 +19,7 @@ pub struct Tick {
 #[veecle_os::runtime::actor]
 pub async fn ticker_actor<T>(
     mut tick_writer: Writer<'_, Tick>,
-) -> Result<Infallible, veecle_os::osal::api::Error>
+) -> Result<Never, veecle_os::osal::api::Error>
 where
     T: TimeAbstraction,
 {
@@ -36,7 +35,7 @@ where
 /// Additionally, prints to stderr if the time between
 /// the previous and current tick differs by more than 10 millis.
 #[veecle_os::runtime::actor]
-pub async fn ticker_reader(mut reader: InitializedReader<'_, Tick>) -> Infallible {
+pub async fn ticker_reader(mut reader: InitializedReader<'_, Tick>) -> Never {
     let mut previous: Option<Instant> = None;
 
     loop {

--- a/veecle-os-examples/common/src/actors/udp.rs
+++ b/veecle-os-examples/common/src/actors/udp.rs
@@ -1,8 +1,8 @@
-use core::convert::Infallible;
 use core::net::SocketAddr;
+use veecle_os::runtime::Never;
 
 #[veecle_os::runtime::actor]
-pub async fn udp_server_actor<S, L>(#[init_context] input: (S, SocketAddr)) -> Infallible
+pub async fn udp_server_actor<S, L>(#[init_context] input: (S, SocketAddr)) -> Never
 where
     S: veecle_os::osal::api::net::udp::UdpSocket,
     L: veecle_os::osal::api::log::LogTarget,
@@ -64,9 +64,7 @@ where
 }
 
 #[veecle_os::runtime::actor]
-pub async fn udp_client_actor<S, L>(
-    #[init_context] input: (S, SocketAddr, SocketAddr),
-) -> Infallible
+pub async fn udp_client_actor<S, L>(#[init_context] input: (S, SocketAddr, SocketAddr)) -> Never
 where
     S: veecle_os::osal::api::net::udp::UdpSocket,
     L: veecle_os::osal::api::log::LogTarget,

--- a/veecle-os-examples/embassy-stm32/src/main.rs
+++ b/veecle-os-examples/embassy-stm32/src/main.rs
@@ -1,11 +1,11 @@
 #![no_std]
 #![no_main]
 
-use core::convert::Infallible;
 use core::num::Wrapping;
 use embassy_executor::Spawner;
 use veecle_os::osal::api::log::LogTarget;
 use veecle_os::osal::api::time::{Duration, TimeAbstraction};
+use veecle_os::runtime::Never;
 use veecle_os::runtime::{Reader, Storable, Writer};
 
 use panic_halt as _;
@@ -15,7 +15,7 @@ pub struct Value(pub usize);
 
 /// An actor that continuously reads and logs updates from `Value`.
 #[veecle_os::runtime::actor]
-pub async fn print_actor<L: LogTarget>(mut reader: Reader<'_, Value>) -> Infallible {
+pub async fn print_actor<L: LogTarget>(mut reader: Reader<'_, Value>) -> Never {
     loop {
         reader.wait_for_update().await.read(|value| {
             if let Some(value) = value {
@@ -27,7 +27,7 @@ pub async fn print_actor<L: LogTarget>(mut reader: Reader<'_, Value>) -> Infalli
 
 /// An actor that continuously increments `Value`.
 #[veecle_os::runtime::actor]
-pub async fn increment_actor<T: TimeAbstraction>(mut writer: Writer<'_, Value>) -> Infallible {
+pub async fn increment_actor<T: TimeAbstraction>(mut writer: Writer<'_, Value>) -> Never {
     let mut counter = Wrapping(0);
     loop {
         writer.write(Value(counter.0)).await;

--- a/veecle-os-examples/freertos-linux/src/bin/alloc.rs
+++ b/veecle-os-examples/freertos-linux/src/bin/alloc.rs
@@ -1,5 +1,3 @@
-use std::convert::Infallible;
-
 use veecle_freertos_integration::{FreeRtosAllocator, Task, TaskPriority, vPortGetHeapStats};
 use veecle_os::osal::api::time::{Duration, TimeAbstraction};
 use veecle_os::osal::freertos::time::Time;
@@ -10,7 +8,7 @@ use veecle_os_examples_common::actors::alloc::BoxActor;
 static GLOBAL: FreeRtosAllocator = unsafe { FreeRtosAllocator::new() };
 
 #[veecle_os::runtime::actor]
-async fn alloc_stat_actor() -> Infallible {
+async fn alloc_stat_actor() -> veecle_os::runtime::Never {
     loop {
         Time::sleep(Duration::from_secs(4)).await.unwrap();
 

--- a/veecle-os-examples/freertos-linux/src/bin/queues.rs
+++ b/veecle-os-examples/freertos-linux/src/bin/queues.rs
@@ -1,6 +1,4 @@
 //! FreeRTOS-Linux example.
-use core::convert::Infallible;
-
 use veecle_freertos_integration::*;
 
 // SAFETY: We don't use any non-FreeRTOS threads.
@@ -10,7 +8,7 @@ static GLOBAL: FreeRtosAllocator = unsafe { FreeRtosAllocator::new() };
 #[veecle_os::runtime::actor]
 async fn queue_actor(
     #[init_context] init_context: (AsyncQueueReceiver<u32>, AsyncQueueSender<i32>),
-) -> Infallible {
+) -> veecle_os::runtime::Never {
     const DATA: i32 = 77;
 
     let (mut queue_receiver, mut queue_sender) = init_context;

--- a/veecle-os-examples/orchestrator-ipc/src/bin/useless-machine.rs
+++ b/veecle-os-examples/orchestrator-ipc/src/bin/useless-machine.rs
@@ -2,7 +2,7 @@
 //!
 //! This implements a [useless machine](https://en.wikipedia.org/wiki/Useless_machine) in the form
 //! of a runtime process that just shuts itself down.
-use core::convert::Infallible;
+use veecle_os::runtime::Never;
 
 use veecle_ipc::{ControlRequest, ControlResponse, Uuid};
 use veecle_os::osal::std::time::{Duration, Time, TimeAbstraction};
@@ -13,7 +13,7 @@ async fn useless_machine_actor(
     #[init_context] id: Uuid,
     mut request: Writer<'_, ControlRequest>,
     response: Reader<'_, ControlResponse>,
-) -> Infallible {
+) -> Never {
     veecle_os::telemetry::info!(
         "useless machine starting, will shut down soon",
         id = id.to_string()

--- a/veecle-os-examples/std/src/bin/alloc.rs
+++ b/veecle-os-examples/std/src/bin/alloc.rs
@@ -1,15 +1,15 @@
 use std::alloc::System;
-use std::convert::Infallible;
 
 use stats_alloc::{INSTRUMENTED_SYSTEM, Region, StatsAlloc};
 use veecle_os::osal::std::time::{Duration, Time, TimeAbstraction};
+use veecle_os::runtime::Never;
 use veecle_os_examples_common::actors::alloc::BoxActor;
 
 #[global_allocator]
 static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
 
 #[veecle_os::runtime::actor]
-async fn alloc_stat_actor() -> Infallible {
+async fn alloc_stat_actor() -> Never {
     let region = Region::new(GLOBAL);
 
     loop {

--- a/veecle-os-runtime-macros/src/actor.rs
+++ b/veecle-os-runtime-macros/src/actor.rs
@@ -271,7 +271,7 @@ pub fn impl_actor(
         syn::ReturnType::Default => {
             return Err(Error::new(
                 parsed_item.sig.span(),
-                "#[actor] functions must return a `Result` or `Infallible`",
+                "#[actor] functions must return a `Result` or `Never`",
             ));
         }
         syn::ReturnType::Type(_, ty) => ty,
@@ -316,7 +316,7 @@ pub fn impl_actor(
                 }
             }
 
-            async fn run(self) -> core::result::Result<core::convert::Infallible, Self::Error> {
+            async fn run(self) -> core::result::Result<#veecle_os_runtime::Never, Self::Error> {
                 let Self {
                     request: #request_argument_names,
                     #context_name,

--- a/veecle-os-runtime-macros/src/lib.rs
+++ b/veecle-os-runtime-macros/src/lib.rs
@@ -12,8 +12,7 @@ mod storable;
 ///
 /// ```rust
 /// use veecle_os_runtime::{Reader, Writer};
-/// # use std::convert::Infallible;
-/// # use veecle_os_runtime::Storable;
+/// # use veecle_os_runtime::{Never, Storable};
 /// #
 /// # #[derive(Debug, PartialEq, Clone, Default, Storable)]
 /// # pub struct Sensor(pub u8);
@@ -23,7 +22,7 @@ mod storable;
 ///     _sensor_reader: Reader<'_, Sensor>,
 ///     _sensor_writer: Writer<'_, Sensor>,
 ///     #[init_context] _my_init_context: u32,
-/// ) -> Infallible {
+/// ) -> Never {
 ///     loop {
 ///         // Do things.
 ///     }
@@ -42,8 +41,7 @@ mod storable;
 /// extern crate veecle_os_runtime as my_veecle_os_runtime;
 ///
 /// use my_veecle_os_runtime::{Reader, Writer};
-/// # use std::convert::Infallible;
-/// # use my_veecle_os_runtime::Storable;
+/// # use my_veecle_os_runtime::{Never, Storable};
 /// #
 /// # #[derive(Debug, PartialEq, Clone, Default, Storable)]
 /// # pub struct Sensor(pub u8);
@@ -53,7 +51,7 @@ mod storable;
 ///     _sensor_reader: Reader<'_, Sensor>,
 ///     _sensor_writer: Writer<'_, Sensor>,
 ///     #[init_context] _my_init_context: u32,
-/// ) -> Infallible {
+/// ) -> Never {
 ///     loop {
 ///         // Do things.
 ///     }

--- a/veecle-os-runtime-macros/test-crates/auto-renamed-crate/src/lib.rs
+++ b/veecle-os-runtime-macros/test-crates/auto-renamed-crate/src/lib.rs
@@ -4,6 +4,6 @@
 pub struct Foo;
 
 #[my_veecle_os_runtime::actor]
-pub async fn bar() -> core::convert::Infallible {
+pub async fn bar() -> my_veecle_os_runtime::Never {
     unimplemented!("testing compilation")
 }

--- a/veecle-os-runtime-macros/test-crates/veecle-os-crate/src/lib.rs
+++ b/veecle-os-runtime-macros/test-crates/veecle-os-crate/src/lib.rs
@@ -4,6 +4,6 @@
 pub struct Foo;
 
 #[veecle_os::runtime::actor]
-pub async fn bar() -> core::convert::Infallible {
+pub async fn bar() -> veecle_os::runtime::Never {
     unimplemented!("testing compilation")
 }

--- a/veecle-os-runtime-macros/tests/ui/actor/bad_renamed_crate.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/bad_renamed_crate.rs
@@ -2,19 +2,18 @@
 pub struct Sensor(pub u8);
 
 #[veecle_os_runtime_macros::actor(crate = "::veecle_os_runtime")]
-async fn macro_test_actor1() -> std::convert::Infallible {
+async fn macro_test_actor1() -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 
 #[veecle_os_runtime_macros::actor(crate())]
-async fn macro_test_actor2() -> std::convert::Infallible {
+async fn macro_test_actor2() -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 
 #[veecle_os_runtime_macros::actor(crate = ::veecle_os_runtime, crate = ::veecle_os_runtime2)]
-async fn macro_test_actor3() -> std::convert::Infallible {
+async fn macro_test_actor3() -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 
-fn main() {
-}
+fn main() {}

--- a/veecle-os-runtime-macros/tests/ui/actor/basic.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/basic.rs
@@ -5,7 +5,7 @@ pub struct Sensor(pub u8);
 async fn macro_test_actor(
     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
     _sensor_writer: veecle_os_runtime::Writer<'_, Sensor>,
-) -> std::convert::Infallible {
+) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/extra_attributes.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/extra_attributes.rs
@@ -5,7 +5,7 @@ pub struct Sensor(pub u8);
 async fn macro_test_actor(
     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
     #[allow(dead_code)] _sensor_writer: veecle_os_runtime::Writer<'_, Sensor>,
-) -> std::convert::Infallible {
+) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/generic/const.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/generic/const.rs
@@ -5,7 +5,7 @@ pub struct Sensor(pub u8);
 async fn const_generic<const N: usize>(
     _reader: veecle_os_runtime::Reader<'_, Sensor>,
     _writer: veecle_os_runtime::Writer<'_, Sensor>,
-) -> core::convert::Infallible {
+) -> veecle_os_runtime::Never {
     core::future::pending().await
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/generic/init_context.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/generic/init_context.rs
@@ -6,7 +6,7 @@ async fn discard<T>(
     _reader: veecle_os_runtime::Reader<'_, Sensor>,
     _writer: veecle_os_runtime::Writer<'_, Sensor>,
     #[init_context] _context: T,
-) -> core::convert::Infallible
+) -> veecle_os_runtime::Never
 where
     T: core::fmt::Debug + 'static,
 {

--- a/veecle-os-runtime-macros/tests/ui/actor/generic/lifetime.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/generic/lifetime.rs
@@ -6,7 +6,7 @@ async fn with_lifetime<'a>(
     _reader: veecle_os_runtime::Reader<'_, Sensor>,
     _writer: veecle_os_runtime::Writer<'_, Sensor>,
     #[init_context] _context: &'a (),
-) -> core::convert::Infallible {
+) -> veecle_os_runtime::Never {
     core::future::pending().await
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/generic/simple.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/generic/simple.rs
@@ -5,7 +5,7 @@ pub struct Sensor(pub u8);
 async fn discard<T>(
     _reader: veecle_os_runtime::Reader<'_, T>,
     _writer: veecle_os_runtime::Writer<'_, T>,
-) -> core::convert::Infallible
+) -> veecle_os_runtime::Never
 where
     T: veecle_os_runtime::Storable + 'static,
 {

--- a/veecle-os-runtime-macros/tests/ui/actor/generic/unused.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/generic/unused.rs
@@ -1,5 +1,5 @@
 #[veecle_os_runtime::actor]
-async fn unused<T>() -> core::convert::Infallible {
+async fn unused<T>() -> veecle_os_runtime::Never {
     core::future::pending().await
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/generic/where.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/generic/where.rs
@@ -5,7 +5,7 @@ pub struct Sensor(pub u8);
 async fn discard<T>(
     _reader: veecle_os_runtime::Reader<'_, T>,
     _writer: veecle_os_runtime::Writer<'_, T>,
-) -> core::convert::Infallible
+) -> veecle_os_runtime::Never
 where
     T: veecle_os_runtime::Storable + 'static,
 {

--- a/veecle-os-runtime-macros/tests/ui/actor/init_context/anonymous_lifetime_generic.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/init_context/anonymous_lifetime_generic.rs
@@ -1,7 +1,7 @@
 pub struct Foo<'a>(&'a u8);
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(#[init_context] _init_context: Foo<'_>) -> std::convert::Infallible {
+async fn macro_test_actor(#[init_context] _init_context: Foo<'_>) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/init_context/anonymous_reference.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/init_context/anonymous_reference.rs
@@ -1,5 +1,5 @@
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(#[init_context] _init_context: &u8) -> std::convert::Infallible {
+async fn macro_test_actor(#[init_context] _init_context: &u8) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/init_context/explicit_anonymous_reference.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/init_context/explicit_anonymous_reference.rs
@@ -1,7 +1,5 @@
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(
-    #[init_context] _init_context: &'_ u8,
-) -> std::convert::Infallible {
+async fn macro_test_actor(#[init_context] _init_context: &'_ u8) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/init_context/int.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/init_context/int.rs
@@ -6,7 +6,7 @@ async fn macro_test_actor(
     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
     _sensor_writer: veecle_os_runtime::Writer<'_, Sensor>,
     #[init_context] _init_context: u8,
-) -> std::convert::Infallible {
+) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/init_context/multiple.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/init_context/multiple.rs
@@ -7,7 +7,7 @@ async fn macro_test_actor(
     _sensor_writer: veecle_os_runtime::Writer<'_, Sensor>,
     #[init_context] _init_context1: u8,
     #[init_context] _init_context2: String,
-) -> std::convert::Infallible {
+) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/init_context/reference_to_static_reference.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/init_context/reference_to_static_reference.rs
@@ -1,9 +1,7 @@
 fn verify_static(_: &'static u8) {}
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(
-    #[init_context] init_context: &&'static u8,
-) -> std::convert::Infallible {
+async fn macro_test_actor(#[init_context] init_context: &&'static u8) -> veecle_os_runtime::Never {
     verify_static(*init_context);
     unreachable!("We only care about the code compiling.");
 }

--- a/veecle-os-runtime-macros/tests/ui/actor/init_context/specific_lifetime.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/init_context/specific_lifetime.rs
@@ -1,7 +1,5 @@
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(
-    #[init_context] _init_context: &'a u8,
-) -> std::convert::Infallible {
+async fn macro_test_actor(#[init_context] _init_context: &'a u8) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/init_context/specific_lifetime.stderr
+++ b/veecle-os-runtime-macros/tests/ui/actor/init_context/specific_lifetime.stderr
@@ -1,5 +1,5 @@
 error: lifetimes on actor arguments must be anonymous or static
- --> tests/ui/actor/init_context/specific_lifetime.rs:3:37
+ --> tests/ui/actor/init_context/specific_lifetime.rs:2:59
   |
-3 |     #[init_context] _init_context: &'a u8,
-  |                                     ^^
+2 | async fn macro_test_actor(#[init_context] _init_context: &'a u8) -> veecle_os_runtime::Never {
+  |                                                           ^^

--- a/veecle-os-runtime-macros/tests/ui/actor/init_context/static_reference.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/init_context/static_reference.rs
@@ -1,9 +1,7 @@
 fn verify_static(_: &'static u8) {}
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(
-    #[init_context] init_context: &'static u8,
-) -> std::convert::Infallible {
+async fn macro_test_actor(#[init_context] init_context: &'static u8) -> veecle_os_runtime::Never {
     verify_static(init_context);
     unreachable!("We only care about the code compiling.");
 }

--- a/veecle-os-runtime-macros/tests/ui/actor/init_context/tuple.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/init_context/tuple.rs
@@ -6,7 +6,7 @@ async fn macro_test_actor(
     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
     _sensor_writer: veecle_os_runtime::Writer<'_, Sensor>,
     #[init_context] _init_context: (u8, u8),
-) -> std::convert::Infallible {
+) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/init_context/unit.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/init_context/unit.rs
@@ -6,7 +6,7 @@ async fn macro_test_actor(
     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
     _sensor_writer: veecle_os_runtime::Writer<'_, Sensor>,
     #[init_context] _init_context: (),
-) -> std::convert::Infallible {
+) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/macro_generated.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/macro_generated.rs
@@ -14,7 +14,7 @@ macro_rules! make_actor {
             _sensor1_reader_exlc: $crate::veecle_os_runtime::ExclusiveReader<'_, Sensor1>,
             _sensor_writer: $crate::veecle_os_runtime::Writer<'_, Sensor>,
             _sensor1_writer: $crate::veecle_os_runtime::Writer<'_, Sensor1>,
-        ) -> std::convert::Infallible {
+        ) -> veecle_os_runtime::Never {
             unreachable!("We only care about the code compiling.");
         }
     };

--- a/veecle-os-runtime-macros/tests/ui/actor/missing_lifetime.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/missing_lifetime.rs
@@ -2,27 +2,29 @@
 pub struct Sensor(pub u8);
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(_reader: veecle_os_runtime::Reader) -> std::convert::Infallible {
+async fn macro_test_actor(_reader: veecle_os_runtime::Reader) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor2(_reader: veecle_os_runtime::Reader) -> std::convert::Infallible {
+async fn macro_test_actor2(_reader: veecle_os_runtime::Reader) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor3(_reader: veecle_os_runtime::Reader<Sensor>) -> std::convert::Infallible {
+async fn macro_test_actor3(_reader: veecle_os_runtime::Reader<Sensor>) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor4(_reader: veecle_os_runtime::Reader<'b, Sensor>) -> std::convert::Infallible {
+async fn macro_test_actor4(
+    _reader: veecle_os_runtime::Reader<'b, Sensor>,
+) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor5(_reader: veecle_os_runtime::Reader) -> std::convert::Infallible {
+async fn macro_test_actor5(_reader: veecle_os_runtime::Reader) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/missing_lifetime.stderr
+++ b/veecle-os-runtime-macros/tests/ui/actor/missing_lifetime.stderr
@@ -1,101 +1,101 @@
 error: lifetimes on actor arguments must be anonymous or static
-  --> tests/ui/actor/missing_lifetime.rs:20:63
+  --> tests/ui/actor/missing_lifetime.rs:21:40
    |
-20 | async fn macro_test_actor4(_reader: veecle_os_runtime::Reader<'b, Sensor>) -> std::convert::Infallible {
-   |                                                               ^^
+21 |     _reader: veecle_os_runtime::Reader<'b, Sensor>,
+   |                                        ^^
 
 error[E0106]: missing lifetime specifier
  --> tests/ui/actor/missing_lifetime.rs:5:55
   |
-5 | async fn macro_test_actor(_reader: veecle_os_runtime::Reader) -> std::convert::Infallible {
+5 | async fn macro_test_actor(_reader: veecle_os_runtime::Reader) -> veecle_os_runtime::Never {
   |                                                       ^^^^^^ expected named lifetime parameter
   |
 help: consider using the `'__dont_use_internal_actor_macro_lifetime` lifetime
   |
-5 | async fn macro_test_actor(_reader: veecle_os_runtime::Reader<'__dont_use_internal_actor_macro_lifetime>) -> std::convert::Infallible {
+5 | async fn macro_test_actor(_reader: veecle_os_runtime::Reader<'__dont_use_internal_actor_macro_lifetime>) -> veecle_os_runtime::Never {
   |                                                             +++++++++++++++++++++++++++++++++++++++++++
 
 error[E0726]: implicit elided lifetime not allowed here
  --> tests/ui/actor/missing_lifetime.rs:5:36
   |
-5 | async fn macro_test_actor(_reader: veecle_os_runtime::Reader) -> std::convert::Infallible {
+5 | async fn macro_test_actor(_reader: veecle_os_runtime::Reader) -> veecle_os_runtime::Never {
   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ expected lifetime parameter
   |
 help: indicate the anonymous lifetime
   |
-5 | async fn macro_test_actor(_reader: veecle_os_runtime::Reader<'_>) -> std::convert::Infallible {
+5 | async fn macro_test_actor(_reader: veecle_os_runtime::Reader<'_>) -> veecle_os_runtime::Never {
   |                                                             ++++
 
 error[E0106]: missing lifetime specifier
   --> tests/ui/actor/missing_lifetime.rs:10:56
    |
-10 | async fn macro_test_actor2(_reader: veecle_os_runtime::Reader) -> std::convert::Infallible {
+10 | async fn macro_test_actor2(_reader: veecle_os_runtime::Reader) -> veecle_os_runtime::Never {
    |                                                        ^^^^^^ expected named lifetime parameter
    |
 help: consider using the `'__dont_use_internal_actor_macro_lifetime` lifetime
    |
-10 | async fn macro_test_actor2(_reader: veecle_os_runtime::Reader<'__dont_use_internal_actor_macro_lifetime>) -> std::convert::Infallible {
+10 | async fn macro_test_actor2(_reader: veecle_os_runtime::Reader<'__dont_use_internal_actor_macro_lifetime>) -> veecle_os_runtime::Never {
    |                                                              +++++++++++++++++++++++++++++++++++++++++++
 
 error[E0726]: implicit elided lifetime not allowed here
   --> tests/ui/actor/missing_lifetime.rs:10:37
    |
-10 | async fn macro_test_actor2(_reader: veecle_os_runtime::Reader) -> std::convert::Infallible {
+10 | async fn macro_test_actor2(_reader: veecle_os_runtime::Reader) -> veecle_os_runtime::Never {
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^ expected lifetime parameter
    |
 help: indicate the anonymous lifetime
    |
-10 | async fn macro_test_actor2(_reader: veecle_os_runtime::Reader<'_>) -> std::convert::Infallible {
+10 | async fn macro_test_actor2(_reader: veecle_os_runtime::Reader<'_>) -> veecle_os_runtime::Never {
    |                                                              ++++
 
 error[E0106]: missing lifetime specifier
   --> tests/ui/actor/missing_lifetime.rs:15:62
    |
-15 | async fn macro_test_actor3(_reader: veecle_os_runtime::Reader<Sensor>) -> std::convert::Infallible {
+15 | async fn macro_test_actor3(_reader: veecle_os_runtime::Reader<Sensor>) -> veecle_os_runtime::Never {
    |                                                              ^ expected named lifetime parameter
    |
 help: consider using the `'__dont_use_internal_actor_macro_lifetime` lifetime
    |
-15 | async fn macro_test_actor3(_reader: veecle_os_runtime::Reader<'__dont_use_internal_actor_macro_lifetime, Sensor>) -> std::convert::Infallible {
+15 | async fn macro_test_actor3(_reader: veecle_os_runtime::Reader<'__dont_use_internal_actor_macro_lifetime, Sensor>) -> veecle_os_runtime::Never {
    |                                                               ++++++++++++++++++++++++++++++++++++++++++
 
 error[E0726]: implicit elided lifetime not allowed here
   --> tests/ui/actor/missing_lifetime.rs:15:37
    |
-15 | async fn macro_test_actor3(_reader: veecle_os_runtime::Reader<Sensor>) -> std::convert::Infallible {
+15 | async fn macro_test_actor3(_reader: veecle_os_runtime::Reader<Sensor>) -> veecle_os_runtime::Never {
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected lifetime parameter
    |
 help: indicate the anonymous lifetime
    |
-15 | async fn macro_test_actor3(_reader: veecle_os_runtime::Reader<'_, Sensor>) -> std::convert::Infallible {
+15 | async fn macro_test_actor3(_reader: veecle_os_runtime::Reader<'_, Sensor>) -> veecle_os_runtime::Never {
    |                                                               +++
 
 error[E0106]: missing lifetime specifier
-  --> tests/ui/actor/missing_lifetime.rs:25:56
+  --> tests/ui/actor/missing_lifetime.rs:27:56
    |
-25 | async fn macro_test_actor5(_reader: veecle_os_runtime::Reader) -> std::convert::Infallible {
+27 | async fn macro_test_actor5(_reader: veecle_os_runtime::Reader) -> veecle_os_runtime::Never {
    |                                                        ^^^^^^ expected named lifetime parameter
    |
 help: consider using the `'__dont_use_internal_actor_macro_lifetime` lifetime
    |
-25 | async fn macro_test_actor5(_reader: veecle_os_runtime::Reader<'__dont_use_internal_actor_macro_lifetime>) -> std::convert::Infallible {
+27 | async fn macro_test_actor5(_reader: veecle_os_runtime::Reader<'__dont_use_internal_actor_macro_lifetime>) -> veecle_os_runtime::Never {
    |                                                              +++++++++++++++++++++++++++++++++++++++++++
 
 error[E0726]: implicit elided lifetime not allowed here
-  --> tests/ui/actor/missing_lifetime.rs:25:37
+  --> tests/ui/actor/missing_lifetime.rs:27:37
    |
-25 | async fn macro_test_actor5(_reader: veecle_os_runtime::Reader) -> std::convert::Infallible {
+27 | async fn macro_test_actor5(_reader: veecle_os_runtime::Reader) -> veecle_os_runtime::Never {
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^ expected lifetime parameter
    |
 help: indicate the anonymous lifetime
    |
-25 | async fn macro_test_actor5(_reader: veecle_os_runtime::Reader<'_>) -> std::convert::Infallible {
+27 | async fn macro_test_actor5(_reader: veecle_os_runtime::Reader<'_>) -> veecle_os_runtime::Never {
    |                                                              ++++
 
 error[E0107]: missing generics for struct `Reader`
  --> tests/ui/actor/missing_lifetime.rs:5:55
   |
-5 | async fn macro_test_actor(_reader: veecle_os_runtime::Reader) -> std::convert::Infallible {
+5 | async fn macro_test_actor(_reader: veecle_os_runtime::Reader) -> veecle_os_runtime::Never {
   |                                                       ^^^^^^ expected 1 generic argument
   |
 note: struct defined here, with 1 generic parameter: `T`
@@ -105,13 +105,13 @@ note: struct defined here, with 1 generic parameter: `T`
   |            ^^^^^^     -
 help: add missing generic argument
   |
-5 | async fn macro_test_actor(_reader: veecle_os_runtime::Reader<T>) -> std::convert::Infallible {
+5 | async fn macro_test_actor(_reader: veecle_os_runtime::Reader<T>) -> veecle_os_runtime::Never {
   |                                                             +++
 
 error[E0107]: missing generics for struct `Reader`
   --> tests/ui/actor/missing_lifetime.rs:10:56
    |
-10 | async fn macro_test_actor2(_reader: veecle_os_runtime::Reader) -> std::convert::Infallible {
+10 | async fn macro_test_actor2(_reader: veecle_os_runtime::Reader) -> veecle_os_runtime::Never {
    |                                                        ^^^^^^ expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
@@ -121,13 +121,13 @@ note: struct defined here, with 1 generic parameter: `T`
    |            ^^^^^^     -
 help: add missing generic argument
    |
-10 | async fn macro_test_actor2(_reader: veecle_os_runtime::Reader<T>) -> std::convert::Infallible {
+10 | async fn macro_test_actor2(_reader: veecle_os_runtime::Reader<T>) -> veecle_os_runtime::Never {
    |                                                              +++
 
 error[E0107]: missing generics for struct `Reader`
-  --> tests/ui/actor/missing_lifetime.rs:25:56
+  --> tests/ui/actor/missing_lifetime.rs:27:56
    |
-25 | async fn macro_test_actor5(_reader: veecle_os_runtime::Reader) -> std::convert::Infallible {
+27 | async fn macro_test_actor5(_reader: veecle_os_runtime::Reader) -> veecle_os_runtime::Never {
    |                                                        ^^^^^^ expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
@@ -137,5 +137,5 @@ note: struct defined here, with 1 generic parameter: `T`
    |            ^^^^^^     -
 help: add missing generic argument
    |
-25 | async fn macro_test_actor5(_reader: veecle_os_runtime::Reader<T>) -> std::convert::Infallible {
+27 | async fn macro_test_actor5(_reader: veecle_os_runtime::Reader<T>) -> veecle_os_runtime::Never {
    |                                                              +++

--- a/veecle-os-runtime-macros/tests/ui/actor/mixed_order.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/mixed_order.rs
@@ -10,7 +10,7 @@ async fn macro_test_actor(
     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
     _sensor_writer: veecle_os_runtime::Writer<'_, Sensor>,
     _actuator_reader: veecle_os_runtime::ExclusiveReader<'_, Actuator>,
-) -> std::convert::Infallible {
+) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/no_args.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/no_args.rs
@@ -1,5 +1,5 @@
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor() -> std::convert::Infallible {
+async fn macro_test_actor() -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/only_init_context_argument.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/only_init_context_argument.rs
@@ -1,5 +1,5 @@
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(#[init_context] foo: u32) -> std::convert::Infallible {
+async fn macro_test_actor(#[init_context] foo: u32) -> veecle_os_runtime::Never {
     let _ = foo;
     unreachable!("We only care about the code compiling.");
 }

--- a/veecle-os-runtime-macros/tests/ui/actor/overlapping_mod.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/overlapping_mod.rs
@@ -7,7 +7,7 @@ pub struct Sensor(pub u8);
 async fn macro_test_actor(
     _sensor_reader: ::veecle_os_runtime::Reader<'_, Sensor>,
     _sensor_writer: ::veecle_os_runtime::Writer<'_, Sensor>,
-) -> std::convert::Infallible {
+) -> ::veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/patterns.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/patterns.rs
@@ -6,7 +6,7 @@ async fn macro_test_actor(
     _: veecle_os_runtime::Reader<'_, Sensor>,
     veecle_os_runtime::Writer { .. }: veecle_os_runtime::Writer<'_, Sensor>,
     #[init_context] (a, [b, c], Sensor { 0: x }): (u8, [u8; 2], Sensor),
-) -> std::convert::Infallible {
+) -> veecle_os_runtime::Never {
     let _: u8 = a + b + c + x;
     unreachable!("We only care about the code compiling.");
 }

--- a/veecle-os-runtime-macros/tests/ui/actor/private_actor.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/private_actor.rs
@@ -3,7 +3,9 @@ mod inner {
     pub struct Sensor(pub u8);
 
     #[veecle_os_runtime_macros::actor]
-    async fn macro_test_actor(_reader: veecle_os_runtime::Reader<'_, Sensor>) -> std::convert::Infallible {
+    async fn macro_test_actor(
+        _reader: veecle_os_runtime::Reader<'_, Sensor>,
+    ) -> veecle_os_runtime::Never {
         unreachable!("We only care about the code compiling.");
     }
 }

--- a/veecle-os-runtime-macros/tests/ui/actor/private_actor.stderr
+++ b/veecle-os-runtime-macros/tests/ui/actor/private_actor.stderr
@@ -1,7 +1,7 @@
 error[E0603]: struct `MacroTestActor` is private
-  --> tests/ui/actor/private_actor.rs:12:25
+  --> tests/ui/actor/private_actor.rs:14:25
    |
-12 |     let _: self::inner::MacroTestActor;
+14 |     let _: self::inner::MacroTestActor;
    |                         ^^^^^^^^^^^^^^ private struct
    |
 note: the struct `MacroTestActor` is defined here

--- a/veecle-os-runtime-macros/tests/ui/actor/renamed_crate.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/renamed_crate.rs
@@ -1,4 +1,6 @@
 mod fake_veecle_os_runtime {
+    pub enum Never {}
+
     pub trait StoreRequest<'a> {}
 
     pub trait Actor<'a> {
@@ -6,7 +8,7 @@ mod fake_veecle_os_runtime {
         type InitContext: core::any::Any + 'a;
         type Error;
         fn new(request: Self::StoreRequest, init_context: Self::InitContext) -> Self;
-        fn run(self) -> impl core::future::Future<Output = Result<core::convert::Infallible, Self::Error>>;
+        fn run(self) -> impl core::future::Future<Output = Result<Never, Self::Error>>;
     }
 
     impl<'a> StoreRequest<'a> for () {}
@@ -14,17 +16,18 @@ mod fake_veecle_os_runtime {
     where
         T: StoreRequest<'a>,
         U: StoreRequest<'a>,
-    {}
+    {
+    }
 
     pub mod __exports {
         pub trait IsActorResult {
             type Error;
-            fn into_result(self) -> Result<core::convert::Infallible, Self::Error>;
+            fn into_result(self) -> Result<super::Never, Self::Error>;
         }
 
-        impl IsActorResult for core::convert::Infallible {
-            type Error = core::convert::Infallible;
-            fn into_result(self) -> Result<core::convert::Infallible, Self::Error> {
+        impl IsActorResult for super::Never {
+            type Error = super::Never;
+            fn into_result(self) -> Result<super::Never, Self::Error> {
                 match self {}
             }
         }
@@ -46,7 +49,8 @@ mod fake_veecle_os_runtime {
     pub fn assert_right_actor_trait<'a, T>()
     where
         T: self::Actor<'a>,
-    {}
+    {
+    }
 }
 
 #[derive(Debug, PartialEq, Clone, Default)]
@@ -57,7 +61,7 @@ async fn macro_test_actor(
     _sensor_reader: fake_veecle_os_runtime::Reader<'_, Sensor>,
     _sensor_reader_excl: fake_veecle_os_runtime::ExclusiveReader<'_, Sensor>,
     _sensor_writer: fake_veecle_os_runtime::Writer<'_, Sensor>,
-) -> std::convert::Infallible {
+) -> fake_veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/return_int.stderr
+++ b/veecle-os-runtime-macros/tests/ui/actor/return_int.stderr
@@ -1,4 +1,4 @@
-error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Result<Infallible, _>` or `Infallible`
+error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Result<Never, _>` or `Never`
  --> tests/ui/actor/return_int.rs:8:6
   |
 8 | ) -> i32 {
@@ -6,10 +6,10 @@ error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Resu
   |
   = help: the trait `IsActorResult` is not implemented for `i32`
   = help: the following other types implement trait `IsActorResult`:
-            Infallible
-            Result<Infallible, E>
+            Never
+            Result<Never, E>
 
-error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Result<Infallible, _>` or `Infallible`
+error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Result<Never, _>` or `Never`
  --> tests/ui/actor/return_int.rs:4:1
   |
 4 | #[veecle_os_runtime_macros::actor]
@@ -17,5 +17,5 @@ error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Resu
   |
   = help: the trait `IsActorResult` is not implemented for `i32`
   = help: the following other types implement trait `IsActorResult`:
-            Infallible
-            Result<Infallible, E>
+            Never
+            Result<Never, E>

--- a/veecle-os-runtime-macros/tests/ui/actor/return_never.stderr
+++ b/veecle-os-runtime-macros/tests/ui/actor/return_never.stderr
@@ -6,7 +6,7 @@ error[E0658]: the `!` type is experimental
   |
   = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
 
-error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Result<Infallible, _>` or `Infallible`
+error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Result<Never, _>` or `Never`
  --> tests/ui/actor/return_never.rs:8:6
   |
 8 | ) -> ! {
@@ -14,10 +14,10 @@ error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Resu
   |
   = help: the trait `IsActorResult` is not implemented for `!`
   = help: the following other types implement trait `IsActorResult`:
-            Infallible
-            Result<Infallible, E>
+            Never
+            Result<Never, E>
 
-error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Result<Infallible, _>` or `Infallible`
+error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Result<Never, _>` or `Never`
  --> tests/ui/actor/return_never.rs:4:1
   |
 4 | #[veecle_os_runtime_macros::actor]
@@ -25,5 +25,5 @@ error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Resu
   |
   = help: the trait `IsActorResult` is not implemented for `!`
   = help: the following other types implement trait `IsActorResult`:
-            Infallible
-            Result<Infallible, E>
+            Never
+            Result<Never, E>

--- a/veecle-os-runtime-macros/tests/ui/actor/return_nothing.stderr
+++ b/veecle-os-runtime-macros/tests/ui/actor/return_nothing.stderr
@@ -1,4 +1,4 @@
-error: #[actor] functions must return a `Result` or `Infallible`
+error: #[actor] functions must return a `Result` or `Never`
  --> tests/ui/actor/return_nothing.rs:5:1
   |
 5 | async fn macro_test_actor(

--- a/veecle-os-runtime-macros/tests/ui/actor/return_ok_int.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/return_ok_int.rs
@@ -1,4 +1,4 @@
-use core::convert::Infallible;
+use veecle_os_runtime::Never;
 
 #[derive(Debug, PartialEq, Clone, Default, veecle_os_runtime::Storable)]
 pub struct Sensor(pub u8);
@@ -7,7 +7,7 @@ pub struct Sensor(pub u8);
 async fn macro_test_actor(
     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
     _sensor_writer: veecle_os_runtime::Writer<'_, Sensor>,
-) -> Result<i32, Infallible> {
+) -> Result<i32, Never> {
     Ok(0)
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/return_ok_int.stderr
+++ b/veecle-os-runtime-macros/tests/ui/actor/return_ok_int.stderr
@@ -1,26 +1,26 @@
-error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Result<Infallible, _>` or `Infallible`
+error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Result<Never, _>` or `Never`
   --> tests/ui/actor/return_ok_int.rs:10:6
    |
-10 | ) -> Result<i32, Infallible> {
+10 | ) -> Result<i32, Never> {
    |      ^^^^^^ not a valid actor return type
    |
-   = help: the trait `IsActorResult` is not implemented for `Result<i32, Infallible>`
-   = help: the trait `IsActorResult` is implemented for `Result<Infallible, E>`
+   = help: the trait `IsActorResult` is not implemented for `Result<i32, Never>`
+   = help: the trait `IsActorResult` is implemented for `Result<Never, E>`
 
-error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Result<Infallible, _>` or `Infallible`
+error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Result<Never, _>` or `Never`
  --> tests/ui/actor/return_ok_int.rs:6:1
   |
 6 | #[veecle_os_runtime_macros::actor]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a valid actor return type
   |
-  = help: the trait `IsActorResult` is not implemented for `Result<i32, Infallible>`
-  = help: the trait `IsActorResult` is implemented for `Result<Infallible, E>`
+  = help: the trait `IsActorResult` is not implemented for `Result<i32, Never>`
+  = help: the trait `IsActorResult` is implemented for `Result<Never, E>`
 
-error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Result<Infallible, _>` or `Infallible`
+error[E0277]: #[veecle_os_runtime::actor] functions should return either a `Result<Never, _>` or `Never`
   --> tests/ui/actor/return_ok_int.rs:10:6
    |
-10 | ) -> Result<i32, Infallible> {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^ not a valid actor return type
+10 | ) -> Result<i32, Never> {
+   |      ^^^^^^^^^^^^^^^^^^ not a valid actor return type
    |
-   = help: the trait `IsActorResult` is not implemented for `Result<i32, Infallible>`
-   = help: the trait `IsActorResult` is implemented for `Result<Infallible, E>`
+   = help: the trait `IsActorResult` is not implemented for `Result<i32, Never>`
+   = help: the trait `IsActorResult` is implemented for `Result<Never, E>`

--- a/veecle-os-runtime-macros/tests/ui/actor/self.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/self.rs
@@ -1,15 +1,15 @@
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(&self) -> std::convert::Infallible {
+async fn macro_test_actor(&self) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(self) -> std::convert::Infallible {
+async fn macro_test_actor(self) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(self: Self) -> std::convert::Infallible {
+async fn macro_test_actor(self: Self) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/self.stderr
+++ b/veecle-os-runtime-macros/tests/ui/actor/self.stderr
@@ -1,17 +1,17 @@
 error: method signature may not contain self
  --> tests/ui/actor/self.rs:2:27
   |
-2 | async fn macro_test_actor(&self) -> std::convert::Infallible {
+2 | async fn macro_test_actor(&self) -> veecle_os_runtime::Never {
   |                           ^
 
 error: method signature may not contain self
  --> tests/ui/actor/self.rs:7:27
   |
-7 | async fn macro_test_actor(self) -> std::convert::Infallible {
+7 | async fn macro_test_actor(self) -> veecle_os_runtime::Never {
   |                           ^^^^
 
 error: method signature may not contain self
   --> tests/ui/actor/self.rs:12:27
    |
-12 | async fn macro_test_actor(self: Self) -> std::convert::Infallible {
+12 | async fn macro_test_actor(self: Self) -> veecle_os_runtime::Never {
    |                           ^^^^

--- a/veecle-os-runtime-macros/tests/ui/actor/static_reference.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/static_reference.rs
@@ -7,7 +7,7 @@ fn verify_static(_: &'static u8) {}
 async fn macro_test_actor(
     reader: veecle_os_runtime::Reader<'_, Reference<'static>>,
     _writer: veecle_os_runtime::Writer<'_, Reference<'static>>,
-) -> std::convert::Infallible {
+) -> veecle_os_runtime::Never {
     verify_static(reader.read_cloned().unwrap().0);
     unreachable!("We only care about the code compiling.");
 }

--- a/veecle-os-runtime-macros/tests/ui/actor/unexpected_argument.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/unexpected_argument.rs
@@ -5,22 +5,22 @@ pub struct Sensor(pub u8);
 async fn macro_test_actor(
     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
     _unexpected: u32,
-) -> std::convert::Infallible {
+) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(_unexpected: u32) -> std::convert::Infallible {
+async fn macro_test_actor(_unexpected: u32) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(_unexpected: <Foo as Bar>::Ty) -> std::convert::Infallible {
+async fn macro_test_actor(_unexpected: <Foo as Bar>::Ty) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(_unexpected: [u32; 0]) -> std::convert::Infallible {
+async fn macro_test_actor(_unexpected: [u32; 0]) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/unexpected_argument.stderr
+++ b/veecle-os-runtime-macros/tests/ui/actor/unexpected_argument.stderr
@@ -7,17 +7,17 @@ error: only "Reader", "ExclusiveReader", "InitializedReader" and "Writer" argume
 error: only "Reader", "ExclusiveReader", "InitializedReader" and "Writer" arguments are allowed
   --> tests/ui/actor/unexpected_argument.rs:13:40
    |
-13 | async fn macro_test_actor(_unexpected: u32) -> std::convert::Infallible {
+13 | async fn macro_test_actor(_unexpected: u32) -> veecle_os_runtime::Never {
    |                                        ^^^
 
 error: only "Reader", "ExclusiveReader", "InitializedReader" and "Writer" arguments are allowed
   --> tests/ui/actor/unexpected_argument.rs:18:40
    |
-18 | async fn macro_test_actor(_unexpected: <Foo as Bar>::Ty) -> std::convert::Infallible {
+18 | async fn macro_test_actor(_unexpected: <Foo as Bar>::Ty) -> veecle_os_runtime::Never {
    |                                        ^
 
 error: only "Reader", "ExclusiveReader", "InitializedReader" and "Writer" arguments are allowed
   --> tests/ui/actor/unexpected_argument.rs:23:40
    |
-23 | async fn macro_test_actor(_unexpected: [u32; 0]) -> std::convert::Infallible {
+23 | async fn macro_test_actor(_unexpected: [u32; 0]) -> veecle_os_runtime::Never {
    |                                        ^^^^^^^^

--- a/veecle-os-runtime-macros/tests/ui/actor/unknown_attribute_argument.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/unknown_attribute_argument.rs
@@ -1,5 +1,5 @@
 #[veecle_os_runtime_macros::actor(foo = "bar")]
-async fn macro_test_actor() -> std::convert::Infallible {
+async fn macro_test_actor() -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/storable/enums.rs
+++ b/veecle-os-runtime-macros/tests/ui/storable/enums.rs
@@ -19,7 +19,7 @@ async fn macro_test_actor(
     _sensor0_writer: veecle_os_runtime::Writer<'_, Sensor0>,
     _sensor1_reader: veecle_os_runtime::Reader<'_, Sensor1>,
     _sensor1_writer: veecle_os_runtime::Writer<'_, Sensor1>,
-) -> std::convert::Infallible {
+) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/storable/generics.rs
+++ b/veecle-os-runtime-macros/tests/ui/storable/generics.rs
@@ -7,7 +7,9 @@ where
 }
 
 #[derive(Debug, veecle_os_runtime_macros::Storable)]
-pub struct Sensor1<T>(std::marker::PhantomData<T>) where T: std::fmt::Debug;
+pub struct Sensor1<T>(std::marker::PhantomData<T>)
+where
+    T: std::fmt::Debug;
 
 #[derive(Debug, veecle_os_runtime_macros::Storable)]
 pub struct Sensor2<const N: usize>([u8; N]);
@@ -20,7 +22,7 @@ async fn macro_test_actor<T, const N: usize>(
     _sensor1_writer: veecle_os_runtime::Writer<'_, Sensor1<T>>,
     _sensor2_reader: veecle_os_runtime::Reader<'_, Sensor2<N>>,
     _sensor2_writer: veecle_os_runtime::Writer<'_, Sensor2<N>>,
-) -> std::convert::Infallible
+) -> veecle_os_runtime::Never
 where
     T: std::fmt::Debug + 'static,
 {

--- a/veecle-os-runtime-macros/tests/ui/storable/structs.rs
+++ b/veecle-os-runtime-macros/tests/ui/storable/structs.rs
@@ -34,7 +34,7 @@ async fn macro_test_actor(
     _sensor2_writer: veecle_os_runtime::Writer<'_, Sensor2>,
     _sensor3_writer: veecle_os_runtime::Writer<'_, Sensor3>,
     _sensor4_writer: veecle_os_runtime::Writer<'_, Sensor4>,
-) -> std::convert::Infallible {
+) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime/src/datastore/exclusive_reader.rs
+++ b/veecle-os-runtime/src/datastore/exclusive_reader.rs
@@ -47,7 +47,7 @@ use crate::datastore::slot::{self, Slot};
 /// # pub struct Foo;
 /// #
 /// #[veecle_os_runtime::actor]
-/// async fn foo_reader(mut reader: ExclusiveReader<'_, Foo>) -> std::convert::Infallible {
+/// async fn foo_reader(mut reader: ExclusiveReader<'_, Foo>) -> veecle_os_runtime::Never {
 ///     loop {
 ///         let value = reader.wait_for_update().await.take();
 ///     }

--- a/veecle-os-runtime/src/datastore/initialized_reader.rs
+++ b/veecle-os-runtime/src/datastore/initialized_reader.rs
@@ -27,7 +27,7 @@ use crate::datastore::{Storable, slot};
 /// # pub struct Foo;
 /// #
 /// #[veecle_os_runtime::actor]
-/// async fn foo_reader(mut reader: InitializedReader<'_, Foo>) -> std::convert::Infallible {
+/// async fn foo_reader(mut reader: InitializedReader<'_, Foo>) -> veecle_os_runtime::Never {
 ///     loop {
 ///         let processed_value = reader.wait_for_update().await.read(|value: &Foo| {
 ///             // Do something with the value.
@@ -36,7 +36,7 @@ use crate::datastore::{Storable, slot};
 /// }
 ///
 /// #[veecle_os_runtime::actor]
-/// async fn foo_reader_complex(mut reader: Reader<'_, Foo>) -> std::convert::Infallible {
+/// async fn foo_reader_complex(mut reader: Reader<'_, Foo>) -> veecle_os_runtime::Never {
 ///     // Do some initialization that must be completed before waiting for the reader to have an initial value.
 ///     let mut reader = reader.wait_init().await;
 ///     loop {

--- a/veecle-os-runtime/src/datastore/reader.rs
+++ b/veecle-os-runtime/src/datastore/reader.rs
@@ -49,7 +49,7 @@ use crate::datastore::slot::{self, Slot};
 /// # pub struct Foo;
 /// #
 /// #[veecle_os_runtime::actor]
-/// async fn foo_reader(mut reader: Reader<'_, Foo>) -> std::convert::Infallible {
+/// async fn foo_reader(mut reader: Reader<'_, Foo>) -> veecle_os_runtime::Never {
 ///     loop {
 ///         let processed_value = reader.wait_for_update().await.read(|value: Option<&Foo>| {
 ///             // do something with the value.

--- a/veecle-os-runtime/src/datastore/writer.rs
+++ b/veecle-os-runtime/src/datastore/writer.rs
@@ -31,7 +31,7 @@ use super::{Storable, generational};
 /// # pub struct Foo;
 /// #
 /// #[veecle_os_runtime::actor]
-/// async fn foo_writer(mut writer: Writer<'_, Foo>) -> std::convert::Infallible {
+/// async fn foo_writer(mut writer: Writer<'_, Foo>) -> veecle_os_runtime::Never {
 ///     loop {
 ///         // This call will yield to any readers needing to read the last value.
 ///         writer.write(Foo::default()).await;
@@ -51,7 +51,7 @@ use super::{Storable, generational};
 /// #[veecle_os_runtime::actor]
 /// async fn foo_writer(
 ///     mut writer: Writer<'_, Foo>,
-/// ) -> std::convert::Infallible {
+/// ) -> veecle_os_runtime::Never {
 ///     loop {
 ///         // This call will yield to any readers needing to read the last value.
 ///         // The closure will run after yielding and right before continuing to the rest of the function.
@@ -74,7 +74,7 @@ use super::{Storable, generational};
 /// # pub struct Foo;
 /// #
 /// #[veecle_os_runtime::actor]
-/// async fn foo_writer(mut writer: Writer<'_, Foo>) -> std::convert::Infallible {
+/// async fn foo_writer(mut writer: Writer<'_, Foo>) -> veecle_os_runtime::Never {
 ///     loop {
 ///         // This call may yield to any readers needing to read the last value.
 ///         writer.ready().await;

--- a/veecle-os-runtime/src/execute.rs
+++ b/veecle-os-runtime/src/execute.rs
@@ -7,6 +7,7 @@
     "
 )]
 
+use crate::Never;
 use crate::actor::{Actor, Datastore, StoreRequest};
 use crate::cons::{Cons, Nil, TupleConsToCons};
 use crate::datastore::{
@@ -352,7 +353,7 @@ where
 pub async fn execute_actor<'a, A>(
     store: Pin<&'a impl Datastore>,
     init_context: A::InitContext,
-) -> core::convert::Infallible
+) -> Never
 where
     A: Actor<'a>,
 {
@@ -373,10 +374,9 @@ where
 /// Execute a given set of actors without heap allocation.
 ///
 /// ```rust
-/// use core::convert::Infallible;
 /// use core::fmt::Debug;
 ///
-/// use veecle_os_runtime::{Reader, Storable, Writer};
+/// use veecle_os_runtime::{Never, Reader, Storable, Writer};
 ///
 /// #[derive(Debug, Clone, PartialEq, Eq, Default, Storable)]
 /// pub struct Ping {
@@ -389,7 +389,7 @@ where
 /// }
 ///
 /// #[veecle_os_runtime::actor]
-/// async fn ping_actor(mut ping: Writer<'_, Ping>, pong: Reader<'_, Pong>) -> Infallible {
+/// async fn ping_actor(mut ping: Writer<'_, Ping>, pong: Reader<'_, Pong>) -> Never {
 ///     let mut value = 0;
 ///     ping.write(Ping { value }).await;
 ///
@@ -407,7 +407,7 @@ where
 /// }
 ///
 /// #[veecle_os_runtime::actor]
-/// async fn pong_actor(mut pong: Writer<'_, Pong>, ping: Reader<'_, Ping>) -> Infallible {
+/// async fn pong_actor(mut pong: Writer<'_, Pong>, ping: Reader<'_, Ping>) -> Never {
 ///     let mut ping = ping.wait_init().await;
 ///     loop {
 ///         let ping = ping.wait_for_update().await.read_cloned();
@@ -452,7 +452,7 @@ macro_rules! execute {
             // To count how many actors there are, we create an array of `()` with the appropriate length.
             const LEN: usize = [$($crate::discard_to_unit!($actor_type),)*].len();
 
-            let futures: [core::pin::Pin<&mut dyn core::future::Future<Output = core::convert::Infallible>>; LEN] =
+            let futures: [core::pin::Pin<&mut dyn core::future::Future<Output = $crate::Never>>; LEN] =
                 $crate::make_futures! {
                     init_contexts: init_contexts,
                     store: store,
@@ -475,7 +475,7 @@ macro_rules! execute {
 
 /// Internal helper to construct an array of pinned futures for given actors + init-contexts + store.
 ///
-/// Returns essentially `[Pin<&mut dyn Future<Output = Infallible>; actors.len()]`, but likely needs annotation at the
+/// Returns essentially `[Pin<&mut dyn Future<Output = Never>; actors.len()]`, but likely needs annotation at the
 /// use site to force the unsize coercion.
 #[doc(hidden)]
 #[macro_export]

--- a/veecle-os-runtime/src/heapfree_executor.rs
+++ b/veecle-os-runtime/src/heapfree_executor.rs
@@ -1,6 +1,6 @@
 //! A multi-task executor that uses statically allocated state for tracking task status.
 
-use core::convert::Infallible;
+use crate::Never;
 use core::fmt::Debug;
 use core::future::Future;
 use core::ops::{Add, Div};
@@ -300,7 +300,7 @@ where
     /// A generational source provided by the datastore.
     source: Pin<&'a generational::Source>,
     shared: &'static ExecutorShared<LEN>,
-    futures: [Pin<&'a mut (dyn Future<Output = Infallible> + 'a)>; LEN],
+    futures: [Pin<&'a mut (dyn Future<Output = Never> + 'a)>; LEN],
 }
 
 impl<const LEN: usize> core::fmt::Debug for Executor<'_, LEN>
@@ -325,7 +325,7 @@ where
     pub fn new(
         shared: &'static ExecutorShared<LEN>,
         source: Pin<&'a generational::Source>,
-        futures: [Pin<&'a mut (dyn Future<Output = Infallible> + 'a)>; LEN],
+        futures: [Pin<&'a mut (dyn Future<Output = Never> + 'a)>; LEN],
     ) -> Self {
         Self {
             source,

--- a/veecle-os-runtime/src/lib.rs
+++ b/veecle-os-runtime/src/lib.rs
@@ -13,10 +13,9 @@
 //! other.
 //!
 //! ```rust
-//! use std::convert::Infallible;
 //! use std::fmt::Debug;
 //!
-//! use veecle_os_runtime::{Reader, Storable, Writer};
+//! use veecle_os_runtime::{Never, Reader, Storable, Writer};
 //!
 //! #[derive(Debug, Clone, PartialEq, Eq, Default, Storable)]
 //! pub struct Ping {
@@ -29,7 +28,7 @@
 //! }
 //!
 //! #[veecle_os_runtime::actor]
-//! async fn ping_actor(mut ping: Writer<'_, Ping>, pong: Reader<'_, Pong>) -> Infallible {
+//! async fn ping_actor(mut ping: Writer<'_, Ping>, pong: Reader<'_, Pong>) -> Never {
 //!     let mut value = 0;
 //!     ping.write(Ping { value }).await;
 //!
@@ -47,7 +46,7 @@
 //! }
 //!
 //! #[veecle_os_runtime::actor]
-//! async fn pong_actor(mut pong: Writer<'_, Pong>, ping: Reader<'_, Ping>) -> Infallible {
+//! async fn pong_actor(mut pong: Writer<'_, Pong>, ping: Reader<'_, Ping>) -> Never {
 //!     let mut ping = ping.wait_init().await;
 //!     loop {
 //!         let ping = ping.wait_for_update().await.read_cloned();
@@ -123,3 +122,22 @@ pub mod __exports {
     pub use crate::execute::{execute_actor, make_store, validate_actors};
     pub use crate::heapfree_executor::{Executor, ExecutorShared};
 }
+
+/// A type that can never be constructed.
+///
+/// Used as the success type in `Result<Never, E>` to indicate that an operation
+/// never returns successfully, only by error. This is semantically clearer than
+/// using `Infallible` which suggests "cannot fail."
+///
+// TODO(https://github.com/rust-lang/rust/issues/35121)
+/// This type will be replaced with the never type [`!`] once it is stabilized.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Never {}
+
+impl core::fmt::Display for Never {
+    fn fmt(&self, _: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match *self {}
+    }
+}
+
+impl core::error::Error for Never {}

--- a/veecle-os-runtime/src/memory_pool.rs
+++ b/veecle-os-runtime/src/memory_pool.rs
@@ -16,9 +16,8 @@
 //! # Example
 //!
 //! ```
-//! use veecle_os_runtime::{ExclusiveReader, Writer};
+//! use veecle_os_runtime::{ExclusiveReader, Never, Writer};
 //! use veecle_os_runtime::memory_pool::{Chunk, MemoryPool};
-//! use core::convert::Infallible;
 //! use veecle_os_runtime::Storable;
 //!
 //! #[derive(Debug)]
@@ -29,7 +28,7 @@
 //! }
 //!
 //! #[veecle_os_runtime::actor]
-//! async fn exclusive_read_actor(mut reader: ExclusiveReader<'_, Data>) -> Infallible {
+//! async fn exclusive_read_actor(mut reader: ExclusiveReader<'_, Data>) -> Never {
 //!     loop {
 //!         if let Some(chunk) = reader.take() {
 //!             println!("Chunk received: {:?}", chunk);
@@ -44,7 +43,7 @@
 //! async fn write_actor(
 //!     mut writer: Writer<'_, Data>,
 //!     #[init_context] pool: &'static MemoryPool<u8, 5>,
-//! ) -> Infallible {
+//! ) -> Never {
 //!     for index in 0..10 {
 //!         writer.write(pool.chunk(index).unwrap()).await;
 //!     }

--- a/veecle-os-runtime/tests/exclusive_reader.rs
+++ b/veecle-os-runtime/tests/exclusive_reader.rs
@@ -1,12 +1,11 @@
 #![expect(missing_docs)]
 
-use core::convert::Infallible;
 use core::fmt::Debug;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use std::future::poll_fn;
 use std::sync::atomic::Ordering::SeqCst;
 use std::task::Poll;
-use veecle_os_runtime::{ExclusiveReader, Reader, Storable, Writer};
+use veecle_os_runtime::{ExclusiveReader, Never, Reader, Storable, Writer};
 
 static READ_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
@@ -14,7 +13,7 @@ static READ_COUNTER: AtomicUsize = AtomicUsize::new(0);
 pub struct Sensor(pub u8);
 
 #[veecle_os_runtime::actor]
-async fn exclusive_read_actor(mut reader: ExclusiveReader<'_, Sensor>) -> Infallible {
+async fn exclusive_read_actor(mut reader: ExclusiveReader<'_, Sensor>) -> Never {
     loop {
         if let Some(value) = reader.take() {
             println!("Value received: {value:?}");
@@ -26,7 +25,7 @@ async fn exclusive_read_actor(mut reader: ExclusiveReader<'_, Sensor>) -> Infall
 }
 
 #[veecle_os_runtime::actor]
-async fn write_actor(mut writer: Writer<'_, Sensor>) -> Infallible {
+async fn write_actor(mut writer: Writer<'_, Sensor>) -> Never {
     for index in 0..10 {
         writer.write(Sensor(index)).await;
     }
@@ -58,7 +57,7 @@ fn main() {
 #[should_panic(expected = "conflict with exclusive reader for `exclusive_reader::Sensor`")]
 fn not_exclusive_first() {
     #[veecle_os_runtime::actor]
-    async fn non_excl_read_actor(_reader: Reader<'_, Sensor>) -> Infallible {
+    async fn non_excl_read_actor(_reader: Reader<'_, Sensor>) -> Never {
         core::future::pending().await
     }
 
@@ -76,7 +75,7 @@ fn not_exclusive_first() {
 #[should_panic(expected = "conflict with exclusive reader for `exclusive_reader::Sensor`")]
 fn not_exclusive_last() {
     #[veecle_os_runtime::actor]
-    async fn non_excl_read_actor(_reader: Reader<'_, Sensor>) -> Infallible {
+    async fn non_excl_read_actor(_reader: Reader<'_, Sensor>) -> Never {
         core::future::pending().await
     }
 

--- a/veecle-os-runtime/tests/execute_macro.rs
+++ b/veecle-os-runtime/tests/execute_macro.rs
@@ -36,7 +36,7 @@ async fn yield_once() {
 async fn sensor_reader_writer(
     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
     _sensor_writer: veecle_os_runtime::Writer<'_, Sensor>,
-) -> core::convert::Infallible {
+) -> veecle_os_runtime::Never {
     yield_once().await;
     panic!("done")
 }
@@ -44,7 +44,7 @@ async fn sensor_reader_writer(
 #[veecle_os_runtime::actor]
 async fn sensor_reader(
     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
-) -> core::convert::Infallible {
+) -> veecle_os_runtime::Never {
     yield_once().await;
     panic!("done")
 }
@@ -52,7 +52,7 @@ async fn sensor_reader(
 #[veecle_os_runtime::actor]
 async fn other_reader(
     _other_reader: veecle_os_runtime::Reader<'_, Other>,
-) -> core::convert::Infallible {
+) -> veecle_os_runtime::Never {
     yield_once().await;
     panic!("done")
 }
@@ -60,7 +60,7 @@ async fn other_reader(
 #[veecle_os_runtime::actor]
 async fn other_exclusive_reader(
     _other_reader: veecle_os_runtime::ExclusiveReader<'_, Other>,
-) -> core::convert::Infallible {
+) -> veecle_os_runtime::Never {
     yield_once().await;
     panic!("done")
 }
@@ -68,7 +68,7 @@ async fn other_exclusive_reader(
 #[veecle_os_runtime::actor]
 async fn other_writer(
     _other_writer: veecle_os_runtime::Writer<'_, Other>,
-) -> core::convert::Infallible {
+) -> veecle_os_runtime::Never {
     yield_once().await;
     panic!("done")
 }
@@ -76,7 +76,7 @@ async fn other_writer(
 #[veecle_os_runtime::actor]
 async fn data_writer(
     _data_writer: veecle_os_runtime::Writer<'_, Data>,
-) -> core::convert::Infallible {
+) -> veecle_os_runtime::Never {
     yield_once().await;
     panic!("done")
 }
@@ -84,7 +84,7 @@ async fn data_writer(
 #[veecle_os_runtime::actor]
 async fn exclusive_data_reader(
     _reader: veecle_os_runtime::ExclusiveReader<'_, Data>,
-) -> core::convert::Infallible {
+) -> veecle_os_runtime::Never {
     yield_once().await;
     panic!("done")
 }
@@ -92,7 +92,7 @@ async fn exclusive_data_reader(
 #[veecle_os_runtime::actor]
 async fn generic_reader<T: veecle_os_runtime::Storable + 'static>(
     _reader: veecle_os_runtime::Reader<'_, T>,
-) -> core::convert::Infallible {
+) -> veecle_os_runtime::Never {
     yield_once().await;
     panic!("done")
 }
@@ -100,7 +100,7 @@ async fn generic_reader<T: veecle_os_runtime::Storable + 'static>(
 #[veecle_os_runtime::actor]
 async fn generic_writer<T: veecle_os_runtime::Storable + 'static>(
     _writer: veecle_os_runtime::Writer<'_, T>,
-) -> core::convert::Infallible {
+) -> veecle_os_runtime::Never {
     yield_once().await;
     panic!("done")
 }
@@ -108,13 +108,13 @@ async fn generic_writer<T: veecle_os_runtime::Storable + 'static>(
 #[veecle_os_runtime::actor]
 async fn contextual_actor<T: core::fmt::Debug>(
     #[init_context] context: T,
-) -> core::convert::Infallible {
+) -> veecle_os_runtime::Never {
     yield_once().await;
     panic!("done {context:?}")
 }
 
 #[veecle_os_runtime::actor]
-async fn referencing_actor(#[init_context] context: &i32) -> core::convert::Infallible {
+async fn referencing_actor(#[init_context] context: &i32) -> veecle_os_runtime::Never {
     yield_once().await;
     panic!("done {context}")
 }

--- a/veecle-os-runtime/tests/memory_pool.rs
+++ b/veecle-os-runtime/tests/memory_pool.rs
@@ -1,6 +1,5 @@
 //! Tests whether the memory pool can be used to pass data through the datastore.
 
-use std::convert::Infallible;
 use std::future::poll_fn;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::task::Poll;
@@ -22,7 +21,9 @@ fn memory_pool() {
     }
 
     #[veecle_os_runtime::actor]
-    async fn exclusive_read_actor(mut reader: ExclusiveReader<'_, Data>) -> Infallible {
+    async fn exclusive_read_actor(
+        mut reader: ExclusiveReader<'_, Data>,
+    ) -> veecle_os_runtime::Never {
         loop {
             if let Some(value) = reader.take() {
                 println!("Value received: {value:?}");
@@ -38,7 +39,7 @@ fn memory_pool() {
     async fn write_actor(
         mut writer: Writer<'_, Data>,
         #[init_context] pool: &'static MemoryPool<u8, 5>,
-    ) -> Infallible {
+    ) -> veecle_os_runtime::Never {
         for index in 0..10 {
             writer.write(pool.chunk(index).unwrap()).await;
         }

--- a/veecle-os-runtime/tests/reader_writer.rs
+++ b/veecle-os-runtime/tests/reader_writer.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 
-use core::convert::Infallible;
 use core::fmt::Debug;
+use veecle_os_runtime::Never;
 
 use futures_test::future::FutureTestExt;
 use veecle_os_runtime::{InitializedReader, Reader, Storable, Writer};
@@ -16,7 +16,7 @@ pub struct UpToDateSignal(Signal);
 async fn filter_actor(
     mut up_to_date: Writer<'_, UpToDateSignal>,
     mut source: InitializedReader<'_, Signal>,
-) -> Infallible {
+) -> Never {
     let mut latest = Signal(0);
 
     loop {

--- a/veecle-os-runtime/tests/sensor-actuator.rs
+++ b/veecle-os-runtime/tests/sensor-actuator.rs
@@ -1,11 +1,11 @@
 #![expect(missing_docs)]
 
-use core::convert::Infallible;
 use core::fmt::Debug;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use std::future::poll_fn;
 use std::sync::Mutex;
 use std::task::Poll;
+use veecle_os_runtime::Never;
 
 use veecle_os_runtime::{CombineReaders, InitializedReader, Storable, Writer};
 
@@ -27,7 +27,7 @@ impl Storable for ActuatorData {
 }
 
 #[veecle_os_runtime::actor]
-async fn sensor_actor(mut sensor_writer: Writer<'_, Sensor>) -> Infallible {
+async fn sensor_actor(mut sensor_writer: Writer<'_, Sensor>) -> Never {
     for sensor in (0..).cycle() {
         sensor_writer.write(sensor).await;
     }
@@ -38,7 +38,7 @@ async fn sensor_actor(mut sensor_writer: Writer<'_, Sensor>) -> Infallible {
 async fn sensor_validation(
     mut sensor_reader: InitializedReader<'_, Sensor>,
     mut actuator_data_reader: InitializedReader<'_, ActuatorData>,
-) -> Infallible {
+) -> Never {
     for expected_sensor in (0..).cycle() {
         let combined_reader = (&mut sensor_reader, &mut actuator_data_reader);
         combined_reader.read(|(a, b)| {
@@ -56,7 +56,7 @@ async fn sensor_validation(
 async fn actuator(
     mut sensor_reader: InitializedReader<'_, Sensor>,
     mut actuator_data_writer: Writer<'_, ActuatorData>,
-) -> Infallible {
+) -> Never {
     loop {
         let value = sensor_reader
             .wait_for_update()
@@ -69,7 +69,7 @@ async fn actuator(
 #[veecle_os_runtime::actor]
 async fn actuator_validation(
     mut actuator_data_reader: InitializedReader<'_, ActuatorData>,
-) -> Infallible {
+) -> Never {
     for expected_actuator in (10..).cycle() {
         actuator_data_reader
             .wait_for_update()
@@ -82,7 +82,7 @@ async fn actuator_validation(
 }
 
 #[veecle_os_runtime::actor]
-async fn printer(mut actuator_data_reader: InitializedReader<'_, ActuatorData>) -> Infallible {
+async fn printer(mut actuator_data_reader: InitializedReader<'_, ActuatorData>) -> Never {
     use std::fmt::Write;
 
     loop {

--- a/veecle-os-runtime/tests/stress_test_execute_macro_actors.rs
+++ b/veecle-os-runtime/tests/stress_test_execute_macro_actors.rs
@@ -19,7 +19,7 @@ macro_rules! make_test {
             #[veecle_os_runtime::actor]
             async fn $ident(
                 reader: veecle_os_runtime::Reader<'_, Data>,
-            ) -> core::convert::Infallible {
+            ) -> veecle_os_runtime::Never {
                 panic!("test completed");
             }
         )*
@@ -27,7 +27,7 @@ macro_rules! make_test {
         #[veecle_os_runtime::actor]
         async fn writer(
             writer: veecle_os_runtime::Writer<'_, Data>,
-        ) -> core::convert::Infallible {
+        ) -> veecle_os_runtime::Never {
             panic!("test completed");
         }
 

--- a/veecle-os-runtime/tests/stress_test_execute_macro_store.rs
+++ b/veecle-os-runtime/tests/stress_test_execute_macro_store.rs
@@ -25,7 +25,7 @@ macro_rules! make_test {
             $(
                 $ident: veecle_os_runtime::Reader<'_, data::$ident>,
             )*
-        ) -> core::convert::Infallible {
+        ) -> veecle_os_runtime::Never {
             panic!("test completed");
         }
 
@@ -34,7 +34,7 @@ macro_rules! make_test {
             $(
                 $ident: veecle_os_runtime::Writer<'_, data::$ident>,
             )*
-        ) -> core::convert::Infallible {
+        ) -> veecle_os_runtime::Never {
             panic!("test completed");
         }
 

--- a/veecle-os-runtime/tests/stress_test_execute_macro_store_and_actors.rs
+++ b/veecle-os-runtime/tests/stress_test_execute_macro_store_and_actors.rs
@@ -25,7 +25,7 @@ macro_rules! make_test {
             async fn $ident(
                 reader: veecle_os_runtime::Reader<'_, data::$ident>,
                 writer: veecle_os_runtime::Writer<'_, data::$ident>,
-            ) -> core::convert::Infallible {
+            ) -> veecle_os_runtime::Never {
                 panic!("test completed");
             }
         )*

--- a/veecle-os-runtime/tests/tokio-runtime-actor.rs
+++ b/veecle-os-runtime/tests/tokio-runtime-actor.rs
@@ -1,6 +1,5 @@
 #![expect(missing_docs)]
 
-use std::convert::Infallible;
 use std::future::poll_fn;
 use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -28,7 +27,7 @@ const BUFFER_SIZE: usize = 16;
 pub struct PipeMessage(pub [u8; BUFFER_SIZE]);
 
 #[veecle_os_runtime::actor]
-async fn write_pipe_runtime_actor(#[init_context] pipe_tx_fd: RawFd) -> Infallible {
+async fn write_pipe_runtime_actor(#[init_context] pipe_tx_fd: RawFd) -> veecle_os_runtime::Never {
     let (pipe_message_channel_tx, mut pipe_message_channel_rx) = mpsc::channel::<PipeMessage>(100);
     thread::spawn(move || {
         let tokio_runtime = Builder::new_current_thread().enable_io().build().unwrap();
@@ -67,7 +66,7 @@ async fn write_pipe_runtime_actor(#[init_context] pipe_tx_fd: RawFd) -> Infallib
 async fn read_pipe_runtime_actor(
     mut pipe_message_writer: Writer<'_, PipeMessage>,
     #[init_context] pipe_rx_fd: RawFd,
-) -> Infallible {
+) -> veecle_os_runtime::Never {
     let (tx, mut rx) = mpsc::channel(100);
     thread::spawn(move || {
         let tokio_runtime = Builder::new_current_thread().enable_io().build().unwrap();
@@ -108,7 +107,7 @@ async fn read_pipe_runtime_actor(
 async fn read_printer(
     mut pipe_message_reader: InitializedReader<'_, PipeMessage>,
     #[init_context] read_counter: &'static AtomicUsize,
-) -> Infallible {
+) -> veecle_os_runtime::Never {
     loop {
         pipe_message_reader
             .wait_for_update()

--- a/veecle-os-test/src/execute.rs
+++ b/veecle-os-test/src/execute.rs
@@ -24,8 +24,7 @@ macro_rules! __make_tuple_cons {
 /// Any store lifetimes in the `validation` argument should be replaced with `'a`.
 ///
 /// ```rust
-/// use core::convert::Infallible;
-/// use veecle_os::runtime::{Reader, Writer, Storable};
+/// use veecle_os::runtime::{Never, Reader, Writer, Storable};
 ///
 /// #[derive(Clone, Copy, Debug, Eq, PartialEq, Storable)]
 /// pub struct Data(u32);
@@ -34,7 +33,7 @@ macro_rules! __make_tuple_cons {
 /// pub struct Trigger;
 ///
 /// #[veecle_os::runtime::actor]
-/// async fn incrementor(mut writer: Writer<'_, Data>, mut trigger: Reader<'_, Trigger>) -> Infallible {
+/// async fn incrementor(mut writer: Writer<'_, Data>, mut trigger: Reader<'_, Trigger>) -> Never {
 ///     loop {
 ///         trigger.wait_for_update().await;
 ///         writer.modify(|data| {
@@ -84,7 +83,7 @@ macro_rules! execute {
         impl<'a> $crate::__exports::veecle_os_runtime::Actor<'a> for Validator<'a> {
             type StoreRequest = $crate::__make_tuple_cons!($($arg_ty,)*);
             type InitContext = $crate::__exports::futures::channel::oneshot::Sender<()>;
-            type Error = core::convert::Infallible;
+            type Error = $crate::__exports::Never;
 
             fn new(store_request: Self::StoreRequest, complete: Self::InitContext) -> Self {
                 Self {
@@ -94,7 +93,7 @@ macro_rules! execute {
                 }
             }
 
-            async fn run(self) -> Result<core::convert::Infallible, Self::Error> {
+            async fn run(self) -> Result<$crate::__exports::Never, Self::Error> {
                 let $crate::__make_tuple_cons!($(mut $arg_pat,)*) = self.store_request;
                 $validation_body;
                 self.complete.send(()).unwrap();
@@ -155,7 +154,7 @@ mod tests {
     #[veecle_os_runtime::actor]
     async fn contextual_actor<T: core::fmt::Debug>(
         #[init_context] _context: T,
-    ) -> core::convert::Infallible {
+    ) -> veecle_os_runtime::Never {
         std::future::pending().await
     }
 

--- a/veecle-os-test/src/lib.rs
+++ b/veecle-os-test/src/lib.rs
@@ -8,15 +8,13 @@
 //! The following example shows how to implement a test:
 //!
 //! ```
-//! use core::convert::Infallible;
-//!
 //! #[derive(Debug, Default, veecle_os_runtime::Storable)]
 //! pub struct Number(usize);
 //!
 //! #[derive(Debug, Default, veecle_os_runtime::Storable)]
 //! pub struct Total(usize);
 //! #
-//! # use veecle_os_runtime::{InitializedReader, Reader, Writer};
+//! # use veecle_os_runtime::{InitializedReader, Never, Reader, Writer};
 //!
 //! // `total_actor` reads numbers from a `Number` reader, keeps a running
 //! // total, and writes running totals to a `Total` writer.
@@ -24,7 +22,7 @@
 //! async fn total_actor(
 //!     mut total: Writer<'_, Total>,
 //!     mut numbers: InitializedReader<'_, Number>,
-//! ) -> Infallible {
+//! ) -> Never {
 //!     let mut sum: usize = 0;
 //!     loop {
 //!         numbers.wait_for_update().await.read(|value| {
@@ -75,4 +73,5 @@ pub use futures::executor::block_on as block_on_future;
 pub mod __exports {
     pub use ::veecle_os_runtime;
     pub use futures;
+    pub use veecle_os_runtime::Never;
 }

--- a/veecle-osal-api/src/time/mod.rs
+++ b/veecle-osal-api/src/time/mod.rs
@@ -12,7 +12,7 @@
 //! to be specified.
 //!
 //! ```rust
-//! use core::convert::Infallible;
+//! use veecle_os_runtime::Never;
 //!
 //! use veecle_osal_api::time::{Duration, TimeAbstraction};
 //! use veecle_osal_std::time::Time;
@@ -24,7 +24,7 @@
 //! }
 //!
 //! #[veecle_os_runtime::actor]
-//! async fn tick_writer<T>(mut writer: Writer<'_, Tick>) -> Infallible
+//! async fn tick_writer<T>(mut writer: Writer<'_, Tick>) -> Never
 //! where
 //!     T: TimeAbstraction,
 //! {
@@ -43,7 +43,7 @@
 //! }
 //!
 //! #[veecle_os_runtime::actor]
-//! async fn tick_reader(mut reader: Reader<'_, Tick>) -> Infallible {
+//! async fn tick_reader(mut reader: Reader<'_, Tick>) -> Never {
 //!     loop {
 //!         reader.wait_for_update().await.read(|tick| {
 //!             println!("[READER TASK] Tick received: {tick:?}");

--- a/veecle-telemetry-ui/examples/common/mod.rs
+++ b/veecle-telemetry-ui/examples/common/mod.rs
@@ -1,8 +1,7 @@
-use std::convert::Infallible;
 use std::fmt::Debug;
 
 use serde::Serialize;
-use veecle_os_runtime::{CombineReaders, InitializedReader, Reader, Storable, Writer};
+use veecle_os_runtime::{CombineReaders, InitializedReader, Never, Reader, Storable, Writer};
 
 #[derive(Debug, Default, Storable, Serialize)]
 pub struct Ping {
@@ -39,7 +38,7 @@ pub async fn ping_loop(ping: &mut Writer<'_, Ping>, pong: &mut Reader<'_, Pong>,
 pub async fn pong_actor(
     mut pong: Writer<'_, Pong>,
     mut ping: InitializedReader<'_, Ping>,
-) -> Infallible {
+) -> Never {
     loop {
         pong_loop(&mut pong, &mut ping).await
     }
@@ -60,10 +59,7 @@ async fn pong_loop(pong: &mut Writer<'_, Pong>, ping: &mut InitializedReader<'_,
 
 /// An actor that continuously reads and logs updates from all debuggable types using a pair of concrete readers.
 #[veecle_os_runtime::actor]
-pub async fn concrete_trace_actor(
-    mut ping: Reader<'_, Ping>,
-    mut pong: Reader<'_, Pong>,
-) -> Infallible {
+pub async fn concrete_trace_actor(mut ping: Reader<'_, Ping>, mut pong: Reader<'_, Pong>) -> Never {
     loop {
         concrete_trace_loop(&mut ping, &mut pong).await;
     }

--- a/veecle-telemetry-ui/examples/continuous.rs
+++ b/veecle-telemetry-ui/examples/continuous.rs
@@ -5,9 +5,7 @@
 //! cargo run --package veecle-telemetry-ui --example continuous | cargo run --package veecle-telemetry-ui
 //! ```
 
-use std::convert::Infallible;
-
-use veecle_os_runtime::{Reader, Writer};
+use veecle_os_runtime::{Never, Reader, Writer};
 use veecle_osal_std::time::{Duration, Time, TimeAbstraction};
 
 use crate::common::{ConcreteTraceActor, Ping, Pong, PongActor, ping_loop};
@@ -20,7 +18,7 @@ mod common;
 async fn ping_actor(
     mut ping: Writer<'_, Ping>,
     mut pong: Reader<'_, Pong>,
-) -> Result<Infallible, veecle_osal_std::Error> {
+) -> Result<Never, veecle_osal_std::Error> {
     let mut value = 0;
 
     loop {

--- a/veecle-telemetry-ui/examples/remote.rs
+++ b/veecle-telemetry-ui/examples/remote.rs
@@ -7,9 +7,7 @@
 //! cargo run --package veecle-telemetry-ui -- ./spans.jsonl
 //! ```
 
-use std::convert::Infallible;
-
-use veecle_os_runtime::{Reader, Writer};
+use veecle_os_runtime::{Never, Reader, Writer};
 
 use crate::common::{ConcreteTraceActor, Ping, Pong, PongActor, ping_loop};
 
@@ -18,7 +16,7 @@ mod common;
 /// An actor that writes `Ping { i }` and waits for `Pong`.
 /// Additionally, it validates that `Pong { value == i + 1 }` for `i = 0..`.
 #[veecle_os_runtime::actor]
-pub async fn ping_actor(mut ping: Writer<'_, Ping>, mut pong: Reader<'_, Pong>) -> Infallible {
+pub async fn ping_actor(mut ping: Writer<'_, Ping>, mut pong: Reader<'_, Pong>) -> Never {
     let mut value = 0;
     loop {
         ping_loop(&mut ping, &mut pong, &mut value).await;


### PR DESCRIPTION
Replace `core::convert::Infallible` with a custom `Never` enum for actor return types to improve semantic clarity.

Using `Result<Infallible, E>` was confusing because `Infallible` semantically means "cannot fail", but it was being used as the success type for operations that never return successfully. The new `Result<Never, E>` type more clearly communicates "this operation never succeeds, only errors".

Changes:
- Add `Never` enum with `Display` and `Error` trait implementations
- Update `IsActorResult` trait to accept `Result<Never, E>` and bare `Never`
- Update `Actor::run()` trait method signature
- Update all actor implementations across examples, tests, and library code
- Update generated code in veecle-os-data-support-can-codegen to use qualified `Never` path
- Update all documentation examples and doctests

This is a breaking change. All actors using `Infallible` must change to `Never`.

The `Never` type will be replaced with the never type `!` once it is stabilized.

Closes: DEV-1193, #109