### PR TITLE
feat: use type system to check actor parameters

### DIFF
--- a/veecle-os-runtime-macros/tests/ui/actor/unexpected_argument.rs
+++ b/veecle-os-runtime-macros/tests/ui/actor/unexpected_argument.rs
@@ -2,7 +2,7 @@
 pub struct Sensor(pub u8);
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(
+async fn macro_test_actor1(
     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
     _unexpected: u32,
 ) -> veecle_os_runtime::Never {
@@ -10,17 +10,42 @@ async fn macro_test_actor(
 }
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(_unexpected: u32) -> veecle_os_runtime::Never {
+async fn macro_test_actor2(_unexpected: u32) -> veecle_os_runtime::Never {
+    unreachable!("We only care about the code compiling.");
+}
+
+pub trait Bar {
+    type Ty;
+}
+pub struct Foo;
+impl Bar for Foo {
+    type Ty = ();
+}
+
+#[veecle_os_runtime_macros::actor]
+async fn macro_test_actor3(_unexpected: <Foo as Bar>::Ty) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(_unexpected: <Foo as Bar>::Ty) -> veecle_os_runtime::Never {
+async fn macro_test_actor4(_unexpected: [u32; 0]) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 
 #[veecle_os_runtime_macros::actor]
-async fn macro_test_actor(_unexpected: [u32; 0]) -> veecle_os_runtime::Never {
+async fn macro_test_actor5(
+    _unexpected: u32,
+    _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
+) -> veecle_os_runtime::Never {
+    unreachable!("We only care about the code compiling.");
+}
+
+#[veecle_os_runtime_macros::actor]
+async fn macro_test_actor6(
+    _unexpected: u32,
+    _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
+    _unexpected1: usize,
+) -> veecle_os_runtime::Never {
     unreachable!("We only care about the code compiling.");
 }
 

--- a/veecle-os-runtime-macros/tests/ui/actor/unexpected_argument.stderr
+++ b/veecle-os-runtime-macros/tests/ui/actor/unexpected_argument.stderr
@@ -1,23 +1,235 @@
-error: only "Reader", "ExclusiveReader", "InitializedReader" and "Writer" arguments are allowed
- --> tests/ui/actor/unexpected_argument.rs:7:18
+error[E0277]: invalid actor parameter type
+ --> tests/ui/actor/unexpected_argument.rs:5:27
   |
-7 |     _unexpected: u32,
-  |                  ^^^
+5 |   async fn macro_test_actor1(
+  |  ___________________________^
+6 | |     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
+7 | |     _unexpected: u32,
+8 | | ) -> veecle_os_runtime::Never {
+  | |_^ the function signature contains parameters that are neither init_context nor reader/writers
+  |
+  = help: the trait `DefinesSlot` is not implemented for `u32`
+  = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
+  = note: parameters passed as initialization context need to be marked with `#[init_context]`
+  = help: the following other types implement trait `DefinesSlot`:
+            ExclusiveReader<'a, T>
+            InitializedReader<'a, T>
+            Reader<'a, T>
+            Writer<'a, T>
 
-error: only "Reader", "ExclusiveReader", "InitializedReader" and "Writer" arguments are allowed
-  --> tests/ui/actor/unexpected_argument.rs:13:40
-   |
-13 | async fn macro_test_actor(_unexpected: u32) -> veecle_os_runtime::Never {
-   |                                        ^^^
+error[E0277]: invalid actor parameter type
+ --> tests/ui/actor/unexpected_argument.rs:5:27
+  |
+5 |   async fn macro_test_actor1(
+  |  ___________________________^
+6 | |     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
+7 | |     _unexpected: u32,
+8 | | ) -> veecle_os_runtime::Never {
+  | |_^ the function signature contains parameters that are neither init_context nor reader/writers
+  |
+  = help: the trait `StoreRequest<'__dont_use_internal_actor_macro_lifetime>` is not implemented for `(u32, (Reader<'__dont_use_internal_actor_macro_lifetime, Sensor>, ()))`
+  = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
+  = note: parameters passed as initialization context need to be marked with `#[init_context]`
+  = help: the following other types implement trait `StoreRequest<'a>`:
+            ExclusiveReader<'a, T>
+            InitializedReader<'a, T>
+            Reader<'a, T>
+            Writer<'a, T>
+note: required by a bound in `veecle_os_runtime::Actor::StoreRequest`
+ --> $WORKSPACE/veecle-os-runtime/src/actor.rs
+  |
+  |     type StoreRequest: StoreRequest<'a>;
+  |                        ^^^^^^^^^^^^^^^^ required by this bound in `Actor::StoreRequest`
 
-error: only "Reader", "ExclusiveReader", "InitializedReader" and "Writer" arguments are allowed
-  --> tests/ui/actor/unexpected_argument.rs:18:40
+error[E0277]: invalid actor parameter type
+  --> tests/ui/actor/unexpected_argument.rs:13:27
    |
-18 | async fn macro_test_actor(_unexpected: <Foo as Bar>::Ty) -> veecle_os_runtime::Never {
-   |                                        ^
+13 | async fn macro_test_actor2(_unexpected: u32) -> veecle_os_runtime::Never {
+   |                           ^^^^^^^^^^^^^^^^^^ the function signature contains parameters that are neither init_context nor reader/writers
+   |
+   = help: the trait `DefinesSlot` is not implemented for `u32`
+   = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
+   = note: parameters passed as initialization context need to be marked with `#[init_context]`
+   = help: the following other types implement trait `DefinesSlot`:
+             ExclusiveReader<'a, T>
+             InitializedReader<'a, T>
+             Reader<'a, T>
+             Writer<'a, T>
 
-error: only "Reader", "ExclusiveReader", "InitializedReader" and "Writer" arguments are allowed
-  --> tests/ui/actor/unexpected_argument.rs:23:40
+error[E0277]: invalid actor parameter type
+  --> tests/ui/actor/unexpected_argument.rs:13:27
    |
-23 | async fn macro_test_actor(_unexpected: [u32; 0]) -> veecle_os_runtime::Never {
-   |                                        ^^^^^^^^
+13 | async fn macro_test_actor2(_unexpected: u32) -> veecle_os_runtime::Never {
+   |                           ^^^^^^^^^^^^^^^^^^ the function signature contains parameters that are neither init_context nor reader/writers
+   |
+   = help: the trait `StoreRequest<'__dont_use_internal_actor_macro_lifetime>` is not implemented for `(u32, ())`
+   = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
+   = note: parameters passed as initialization context need to be marked with `#[init_context]`
+   = help: the following other types implement trait `StoreRequest<'a>`:
+             ExclusiveReader<'a, T>
+             InitializedReader<'a, T>
+             Reader<'a, T>
+             Writer<'a, T>
+note: required by a bound in `veecle_os_runtime::Actor::StoreRequest`
+  --> $WORKSPACE/veecle-os-runtime/src/actor.rs
+   |
+   |     type StoreRequest: StoreRequest<'a>;
+   |                        ^^^^^^^^^^^^^^^^ required by this bound in `Actor::StoreRequest`
+
+error[E0277]: invalid actor parameter type
+  --> tests/ui/actor/unexpected_argument.rs:26:27
+   |
+26 | async fn macro_test_actor3(_unexpected: <Foo as Bar>::Ty) -> veecle_os_runtime::Never {
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the function signature contains parameters that are neither init_context nor reader/writers
+   |
+   = help: the trait `DefinesSlot` is not implemented for `()`
+   = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
+   = note: parameters passed as initialization context need to be marked with `#[init_context]`
+   = help: the following other types implement trait `DefinesSlot`:
+             ExclusiveReader<'a, T>
+             InitializedReader<'a, T>
+             Reader<'a, T>
+             Writer<'a, T>
+
+error[E0277]: invalid actor parameter type
+  --> tests/ui/actor/unexpected_argument.rs:31:27
+   |
+31 | async fn macro_test_actor4(_unexpected: [u32; 0]) -> veecle_os_runtime::Never {
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^ the function signature contains parameters that are neither init_context nor reader/writers
+   |
+   = help: the trait `DefinesSlot` is not implemented for `[u32; 0]`
+   = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
+   = note: parameters passed as initialization context need to be marked with `#[init_context]`
+   = help: the following other types implement trait `DefinesSlot`:
+             ExclusiveReader<'a, T>
+             InitializedReader<'a, T>
+             Reader<'a, T>
+             Writer<'a, T>
+
+error[E0277]: invalid actor parameter type
+  --> tests/ui/actor/unexpected_argument.rs:31:27
+   |
+31 | async fn macro_test_actor4(_unexpected: [u32; 0]) -> veecle_os_runtime::Never {
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^ the function signature contains parameters that are neither init_context nor reader/writers
+   |
+   = help: the trait `StoreRequest<'__dont_use_internal_actor_macro_lifetime>` is not implemented for `([u32; 0], ())`
+   = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
+   = note: parameters passed as initialization context need to be marked with `#[init_context]`
+   = help: the following other types implement trait `StoreRequest<'a>`:
+             ExclusiveReader<'a, T>
+             InitializedReader<'a, T>
+             Reader<'a, T>
+             Writer<'a, T>
+note: required by a bound in `veecle_os_runtime::Actor::StoreRequest`
+  --> $WORKSPACE/veecle-os-runtime/src/actor.rs
+   |
+   |     type StoreRequest: StoreRequest<'a>;
+   |                        ^^^^^^^^^^^^^^^^ required by this bound in `Actor::StoreRequest`
+
+error[E0277]: invalid actor parameter type
+  --> tests/ui/actor/unexpected_argument.rs:36:27
+   |
+36 |   async fn macro_test_actor5(
+   |  ___________________________^
+37 | |     _unexpected: u32,
+38 | |     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
+39 | | ) -> veecle_os_runtime::Never {
+   | |_^ the function signature contains parameters that are neither init_context nor reader/writers
+   |
+   = help: the trait `DefinesSlot` is not implemented for `u32`
+   = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
+   = note: parameters passed as initialization context need to be marked with `#[init_context]`
+   = help: the following other types implement trait `DefinesSlot`:
+             ExclusiveReader<'a, T>
+             InitializedReader<'a, T>
+             Reader<'a, T>
+             Writer<'a, T>
+
+error[E0277]: invalid actor parameter type
+  --> tests/ui/actor/unexpected_argument.rs:36:27
+   |
+36 |   async fn macro_test_actor5(
+   |  ___________________________^
+37 | |     _unexpected: u32,
+38 | |     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
+39 | | ) -> veecle_os_runtime::Never {
+   | |_^ the function signature contains parameters that are neither init_context nor reader/writers
+   |
+   = help: the trait `StoreRequest<'__dont_use_internal_actor_macro_lifetime>` is not implemented for `(Reader<'__dont_use_internal_actor_macro_lifetime, Sensor>, (u32, ()))`
+   = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
+   = note: parameters passed as initialization context need to be marked with `#[init_context]`
+   = help: the following other types implement trait `StoreRequest<'a>`:
+             ExclusiveReader<'a, T>
+             InitializedReader<'a, T>
+             Reader<'a, T>
+             Writer<'a, T>
+note: required by a bound in `veecle_os_runtime::Actor::StoreRequest`
+  --> $WORKSPACE/veecle-os-runtime/src/actor.rs
+   |
+   |     type StoreRequest: StoreRequest<'a>;
+   |                        ^^^^^^^^^^^^^^^^ required by this bound in `Actor::StoreRequest`
+
+error[E0277]: invalid actor parameter type
+  --> tests/ui/actor/unexpected_argument.rs:44:27
+   |
+44 |   async fn macro_test_actor6(
+   |  ___________________________^
+45 | |     _unexpected: u32,
+46 | |     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
+47 | |     _unexpected1: usize,
+48 | | ) -> veecle_os_runtime::Never {
+   | |_^ the function signature contains parameters that are neither init_context nor reader/writers
+   |
+   = help: the trait `DefinesSlot` is not implemented for `usize`
+   = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
+   = note: parameters passed as initialization context need to be marked with `#[init_context]`
+   = help: the following other types implement trait `DefinesSlot`:
+             ExclusiveReader<'a, T>
+             InitializedReader<'a, T>
+             Reader<'a, T>
+             Writer<'a, T>
+
+error[E0277]: invalid actor parameter type
+  --> tests/ui/actor/unexpected_argument.rs:44:27
+   |
+44 |   async fn macro_test_actor6(
+   |  ___________________________^
+45 | |     _unexpected: u32,
+46 | |     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
+47 | |     _unexpected1: usize,
+48 | | ) -> veecle_os_runtime::Never {
+   | |_^ the function signature contains parameters that are neither init_context nor reader/writers
+   |
+   = help: the trait `DefinesSlot` is not implemented for `u32`
+   = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
+   = note: parameters passed as initialization context need to be marked with `#[init_context]`
+   = help: the following other types implement trait `DefinesSlot`:
+             ExclusiveReader<'a, T>
+             InitializedReader<'a, T>
+             Reader<'a, T>
+             Writer<'a, T>
+
+error[E0277]: invalid actor parameter type
+  --> tests/ui/actor/unexpected_argument.rs:44:27
+   |
+44 |   async fn macro_test_actor6(
+   |  ___________________________^
+45 | |     _unexpected: u32,
+46 | |     _sensor_reader: veecle_os_runtime::Reader<'_, Sensor>,
+47 | |     _unexpected1: usize,
+48 | | ) -> veecle_os_runtime::Never {
+   | |_^ the function signature contains parameters that are neither init_context nor reader/writers
+   |
+   = help: the trait `StoreRequest<'__dont_use_internal_actor_macro_lifetime>` is not implemented for `(usize, (Reader<'__dont_use_internal_actor_macro_lifetime, Sensor>, (u32, ())))`
+   = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
+   = note: parameters passed as initialization context need to be marked with `#[init_context]`
+   = help: the following other types implement trait `StoreRequest<'a>`:
+             ExclusiveReader<'a, T>
+             InitializedReader<'a, T>
+             Reader<'a, T>
+             Writer<'a, T>
+note: required by a bound in `veecle_os_runtime::Actor::StoreRequest`
+  --> $WORKSPACE/veecle-os-runtime/src/actor.rs
+   |
+   |     type StoreRequest: StoreRequest<'a>;
+   |                        ^^^^^^^^^^^^^^^^ required by this bound in `Actor::StoreRequest`

--- a/veecle-os-runtime/src/actor.rs
+++ b/veecle-os-runtime/src/actor.rs
@@ -141,6 +141,12 @@ pub trait Actor<'a> {
 /// This trait is not intended for direct usage by users.
 // Developer notes: This works by using type inference via `Datastore::reader` etc. to request `Reader`s etc. from the
 // `Datastore`.
+#[diagnostic::on_unimplemented(
+    message = "invalid actor parameter type",
+    label = "the function signature contains parameters that are neither init_context nor reader/writers",
+    note = "only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters",
+    note = "parameters passed as initialization context need to be marked with `#[init_context]`"
+)]
 pub trait StoreRequest<'a>: sealed::Sealed {
     /// Requests an instance of `Self` from the [`Datastore`].
     ///
@@ -257,6 +263,7 @@ where
 }
 
 /// Implements a no-op for Actors that do not read or write any values.
+#[diagnostic::do_not_recommend]
 impl<'a> StoreRequest<'a> for () {
     async fn request(_store: Pin<&'a impl Datastore>, _requestor: &'static str) -> Self {}
 }
@@ -316,6 +323,7 @@ macro_rules! impl_request_helper {
 
         #[cfg_attr(docsrs, doc(fake_variadic))]
         /// This trait is implemented for tuples up to seven items long.
+        #[diagnostic::do_not_recommend]
         impl<'a, $t> StoreRequest<'a> for ($t,)
         where
             $t: StoreRequest<'a>,
@@ -334,6 +342,7 @@ macro_rules! impl_request_helper {
         { }
 
         #[cfg_attr(docsrs, doc(hidden))]
+        #[diagnostic::do_not_recommend]
         impl<'a, $($t),*> StoreRequest<'a> for ( $( $t, )* )
         where
             $($t: StoreRequest<'a>),*
@@ -396,6 +405,12 @@ impl IsActorResult for Never {
 /// For a [`Writer`] - [`Reader`] combination, the `Writer` defines the slot, as that is the unique side.
 /// As a consequence, every possible combination must have a side that defines the slot.
 #[doc(hidden)]
+#[diagnostic::on_unimplemented(
+    message = "invalid actor parameter type",
+    label = "the function signature contains parameters that are neither init_context nor reader/writers",
+    note = "only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters",
+    note = "parameters passed as initialization context need to be marked with `#[init_context]`"
+)]
 pub trait DefinesSlot {
     /// The slot cons list for this store request type.
     ///


### PR DESCRIPTION
Instead of checking for specific strings in the parameter list, we use the type system and provide a helpful error message via `diagnostic::on_unimplemented`.

As far as I can tell, it's not possible to highlight only the offending type/parameter. We could add a method like `pub fn assert_store_request<'a, T: StoreRequest<'a>>() {}` to provide errors that highlight only the offending type/parameter, but error messages generated by this approach are listed in addition to and after the already existing error messages. Thus they are mostly adding to the noise, rather than helping. The error message encountered first lists the offending type in the `help` text, which, in combination with the highlighted parameter list, should be clear enough.

Fixes: DEV-1398