### PR TITLE
refactor!: refactor `Writer` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@
 * **breaking** Telemetry execution id is replaced by separate thread and process ids to uniquely identify thread/task combinations.
 * **breaking** `ConsoleJsonExporter` is no longer a unit struct, replace usage with `ConsoleJsonExporter::DEFAULT`.
 * **breaking** Removed `Writer::read` method.
-* **breaking** `Writer::modify` closure must now return `bool` indicating whether the value was modified.
-  Readers are only notified when the closure returns `true`.
+* **breaking** `Writer::modify` closure now receives a `Modify` wrapper instead of `&mut Option<T>`.
+  Readers are only notified when the value is mutably accessed via `DerefMut`.
 * **breaking** `Reader`, `Writer`, and `ExclusiveReader` types are now exported from the `single_writer` module.
   * `use veecle_os_runtime::Reader` becomes `use veecle_os_runtime::single_writer::Reader`.
   * `use veecle_os::runtime::Writer` becomes `use veecle_os::runtime::single_writer::Writer`.

--- a/veecle-os-runtime/src/datastore/mod.rs
+++ b/veecle-os-runtime/src/datastore/mod.rs
@@ -6,6 +6,7 @@
 //! [`Actor`]: crate::actor::Actor
 
 mod combine_readers;
+mod modify;
 pub mod single_writer;
 mod slot;
 mod storable;
@@ -13,6 +14,7 @@ mod store_request;
 pub(crate) mod sync;
 
 pub use self::combine_readers::{CombinableReader, CombineReaders};
+pub use self::modify::Modify;
 pub use self::slot::DefinesSlot;
 pub(crate) use self::slot::{SlotTrait, format_types};
 pub use self::storable::Storable;

--- a/veecle-os-runtime/src/datastore/modify.rs
+++ b/veecle-os-runtime/src/datastore/modify.rs
@@ -1,0 +1,43 @@
+use core::fmt::{Debug, Formatter};
+use core::ops::{Deref, DerefMut};
+
+/// A wrapper around `&mut Option<T>` that allows inspecting or modifying the value.
+///
+/// Modifying the value marks it as modified and notifies readers.
+pub struct Modify<'a, T> {
+    pub(crate) inner: &'a mut Option<T>,
+    pub(crate) modified: &'a mut bool,
+}
+
+impl<'a, T> Modify<'a, T> {
+    /// Creates a new instance.
+    pub(crate) fn new(inner: &'a mut Option<T>, modified: &'a mut bool) -> Self {
+        Self { inner, modified }
+    }
+}
+
+impl<'a, T> Debug for Modify<'a, T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Modify")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl<'a, T> Deref for Modify<'a, T> {
+    type Target = Option<T>;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner
+    }
+}
+
+impl<'a, T> DerefMut for Modify<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        *self.modified = true;
+        self.inner
+    }
+}

--- a/veecle-os-runtime/src/datastore/single_writer/slot.rs
+++ b/veecle-os-runtime/src/datastore/single_writer/slot.rs
@@ -102,17 +102,13 @@ where
         f(&*self.borrow())
     }
 
-    /// Updates the value in-place and returns the closure's return value.
-    ///
-    /// The supplied closure should return `true` if the value was modified and `false` if not.
-    ///
-    /// Stores the provided `span_context` to connect this write to the next read operation.
+    /// Updates the value in-place and stores the provided `span_context` to connect this write to the next read operation.
     #[veecle_telemetry::instrument]
     pub(crate) fn modify(
         &self,
-        f: impl FnOnce(&mut Option<T::DataType>) -> bool,
+        f: impl FnOnce(&mut Option<T::DataType>),
         span_context: Option<SpanContext>,
-    ) -> bool {
+    ) {
         f(&mut *self.borrow_mut(span_context))
     }
 

--- a/veecle-os-runtime/src/lib.rs
+++ b/veecle-os-runtime/src/lib.rs
@@ -113,7 +113,7 @@ pub mod memory_pool;
 
 pub use self::actor::{Actor, StoreRequest, actor};
 pub use self::datastore::single_writer;
-pub use self::datastore::{CombinableReader, CombineReaders, Storable};
+pub use self::datastore::{CombinableReader, CombineReaders, Modify, Storable};
 
 /// Internal exports for proc-macro and `macro_rules!` purposes.
 #[doc(hidden)]

--- a/veecle-os-test/src/execute.rs
+++ b/veecle-os-test/src/execute.rs
@@ -19,9 +19,8 @@
 /// async fn incrementor(mut writer: Writer<'_, Data>, mut trigger: Reader<'_, Trigger>) -> Never {
 ///     loop {
 ///         trigger.wait_for_update().await;
-///         writer.modify(|data| {
+///         writer.modify(|mut data| {
 ///             *data = Some(data.map_or(Data(0), |data| Data(data.0 + 1)));
-///             true
 ///         }).await;
 ///     }
 /// }


### PR DESCRIPTION
The `Writer::read` method doesn't make much sense. The actor containing the writer knows the last value it wrote to the slot anyway. If a conditional write is needed, the `modify` method can be used. It now supports indicating whether the value was modified or not.