### PR TITLE
feat: add MPSC (multiple-producer, single-consumer) slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Veecle OS
 
+* Added MPSC (multiple-producer, single-consumer) slot with `mpsc::Writer` and `mpsc::Reader` types.
 * **breaking** Removed `InitializedReader`.
   Use `Reader` with the new `read_updated` method instead.
   * `reader.wait_init().await` is no longer needed.

--- a/veecle-os-runtime-macros/tests/ui/actor/missing_lifetime.stderr
+++ b/veecle-os-runtime-macros/tests/ui/actor/missing_lifetime.stderr
@@ -92,7 +92,7 @@ help: indicate the anonymous lifetime
 27 | async fn macro_test_actor5(_reader: veecle_os_runtime::single_writer::Reader<'_>) -> veecle_os_runtime::Never {
    |                                                                             ++++
 
-error[E0107]: missing generics for struct `Reader`
+error[E0107]: missing generics for struct `veecle_os_runtime::single_writer::Reader`
  --> tests/ui/actor/missing_lifetime.rs:5:70
   |
 5 | async fn macro_test_actor(_reader: veecle_os_runtime::single_writer::Reader) -> veecle_os_runtime::Never {
@@ -108,7 +108,7 @@ help: add missing generic argument
 5 | async fn macro_test_actor(_reader: veecle_os_runtime::single_writer::Reader<T>) -> veecle_os_runtime::Never {
   |                                                                            +++
 
-error[E0107]: missing generics for struct `Reader`
+error[E0107]: missing generics for struct `veecle_os_runtime::single_writer::Reader`
   --> tests/ui/actor/missing_lifetime.rs:10:71
    |
 10 | async fn macro_test_actor2(_reader: veecle_os_runtime::single_writer::Reader) -> veecle_os_runtime::Never {
@@ -124,7 +124,7 @@ help: add missing generic argument
 10 | async fn macro_test_actor2(_reader: veecle_os_runtime::single_writer::Reader<T>) -> veecle_os_runtime::Never {
    |                                                                             +++
 
-error[E0107]: missing generics for struct `Reader`
+error[E0107]: missing generics for struct `veecle_os_runtime::single_writer::Reader`
   --> tests/ui/actor/missing_lifetime.rs:27:71
    |
 27 | async fn macro_test_actor5(_reader: veecle_os_runtime::single_writer::Reader) -> veecle_os_runtime::Never {

--- a/veecle-os-runtime-macros/tests/ui/actor/unexpected_argument.stderr
+++ b/veecle-os-runtime-macros/tests/ui/actor/unexpected_argument.stderr
@@ -11,27 +11,12 @@ error[E0277]: invalid actor parameter type
   = help: the trait `DefinesSlot` is not implemented for `u32`
   = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
   = note: parameters passed as initialization context need to be marked with `#[init_context]`
-help: the following other types implement trait `DefinesSlot`
-  |
- ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/writer.rs
-  |
-  | / impl<'a, T> DefinesSlot for Writer<'a, T>
-  | | where
-  | |     T: Storable,
-  | |________________^ `Writer<'a, T>`
- --> $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/reader.rs
-  |
-  | / impl<T> DefinesSlot for Reader<'_, T>
-  | | where
-  | |     T: Storable,
-  | |________________^ `Reader<'_, T>`
-  |
- ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/exclusive_reader.rs
-  |
-  | / impl<T> DefinesSlot for ExclusiveReader<'_, T>
-  | | where
-  | |     T: Storable,
-  | |________________^ `ExclusiveReader<'_, T>`
+  = help: the following other types implement trait `DefinesSlot`:
+            ExclusiveReader<'_, T>
+            veecle_os_runtime::mpsc::Reader<'_, T, N>
+            veecle_os_runtime::mpsc::Writer<'_, T, N>
+            veecle_os_runtime::single_writer::Reader<'_, T>
+            veecle_os_runtime::single_writer::Writer<'a, T>
 
 error[E0277]: invalid actor parameter type
  --> tests/ui/actor/unexpected_argument.rs:5:27
@@ -43,30 +28,15 @@ error[E0277]: invalid actor parameter type
 8 | | ) -> veecle_os_runtime::Never {
   | |_^ the function signature contains parameters that are neither init_context nor reader/writers
   |
-  = help: the trait `StoreRequest<'__dont_use_internal_actor_macro_lifetime>` is not implemented for `(u32, (Reader<'__dont_use_internal_actor_macro_lifetime, Sensor>, ()))`
+  = help: the trait `StoreRequest<'__dont_use_internal_actor_macro_lifetime>` is not implemented for `(u32, (veecle_os_runtime::single_writer::Reader<'__dont_use_internal_actor_macro_lifetime, Sensor>, ()))`
   = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
   = note: parameters passed as initialization context need to be marked with `#[init_context]`
-help: the following other types implement trait `StoreRequest<'a>`
-  |
- ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/writer.rs
-  |
-  | / impl<'a, T> StoreRequest<'a> for Writer<'a, T>
-  | | where
-  | |     T: Storable + 'static,
-  | |__________________________^ `Writer<'a, T>`
- --> $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/reader.rs
-  |
-  | / impl<'a, T> StoreRequest<'a> for Reader<'a, T>
-  | | where
-  | |     T: Storable + 'static,
-  | |__________________________^ `Reader<'a, T>`
-  |
- ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/exclusive_reader.rs
-  |
-  | / impl<'a, T> StoreRequest<'a> for ExclusiveReader<'a, T>
-  | | where
-  | |     T: Storable + 'static,
-  | |__________________________^ `ExclusiveReader<'a, T>`
+  = help: the following other types implement trait `StoreRequest<'a>`:
+            ExclusiveReader<'a, T>
+            veecle_os_runtime::mpsc::Reader<'a, T, N>
+            veecle_os_runtime::mpsc::Writer<'a, T, N>
+            veecle_os_runtime::single_writer::Reader<'a, T>
+            veecle_os_runtime::single_writer::Writer<'a, T>
 note: required by a bound in `veecle_os_runtime::Actor::StoreRequest`
  --> $WORKSPACE/veecle-os-runtime/src/actor.rs
   |
@@ -82,27 +52,12 @@ error[E0277]: invalid actor parameter type
    = help: the trait `DefinesSlot` is not implemented for `u32`
    = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
    = note: parameters passed as initialization context need to be marked with `#[init_context]`
-help: the following other types implement trait `DefinesSlot`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/writer.rs
-   |
-   | / impl<'a, T> DefinesSlot for Writer<'a, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `Writer<'a, T>`
-  --> $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/reader.rs
-   |
-   | / impl<T> DefinesSlot for Reader<'_, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `Reader<'_, T>`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/exclusive_reader.rs
-   |
-   | / impl<T> DefinesSlot for ExclusiveReader<'_, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `ExclusiveReader<'_, T>`
+   = help: the following other types implement trait `DefinesSlot`:
+             ExclusiveReader<'_, T>
+             veecle_os_runtime::mpsc::Reader<'_, T, N>
+             veecle_os_runtime::mpsc::Writer<'_, T, N>
+             veecle_os_runtime::single_writer::Reader<'_, T>
+             veecle_os_runtime::single_writer::Writer<'a, T>
 
 error[E0277]: invalid actor parameter type
   --> tests/ui/actor/unexpected_argument.rs:13:27
@@ -113,27 +68,12 @@ error[E0277]: invalid actor parameter type
    = help: the trait `StoreRequest<'__dont_use_internal_actor_macro_lifetime>` is not implemented for `(u32, ())`
    = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
    = note: parameters passed as initialization context need to be marked with `#[init_context]`
-help: the following other types implement trait `StoreRequest<'a>`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/writer.rs
-   |
-   | / impl<'a, T> StoreRequest<'a> for Writer<'a, T>
-   | | where
-   | |     T: Storable + 'static,
-   | |__________________________^ `Writer<'a, T>`
-  --> $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/reader.rs
-   |
-   | / impl<'a, T> StoreRequest<'a> for Reader<'a, T>
-   | | where
-   | |     T: Storable + 'static,
-   | |__________________________^ `Reader<'a, T>`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/exclusive_reader.rs
-   |
-   | / impl<'a, T> StoreRequest<'a> for ExclusiveReader<'a, T>
-   | | where
-   | |     T: Storable + 'static,
-   | |__________________________^ `ExclusiveReader<'a, T>`
+   = help: the following other types implement trait `StoreRequest<'a>`:
+             ExclusiveReader<'a, T>
+             veecle_os_runtime::mpsc::Reader<'a, T, N>
+             veecle_os_runtime::mpsc::Writer<'a, T, N>
+             veecle_os_runtime::single_writer::Reader<'a, T>
+             veecle_os_runtime::single_writer::Writer<'a, T>
 note: required by a bound in `veecle_os_runtime::Actor::StoreRequest`
   --> $WORKSPACE/veecle-os-runtime/src/actor.rs
    |
@@ -149,27 +89,12 @@ error[E0277]: invalid actor parameter type
    = help: the trait `DefinesSlot` is not implemented for `()`
    = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
    = note: parameters passed as initialization context need to be marked with `#[init_context]`
-help: the following other types implement trait `DefinesSlot`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/writer.rs
-   |
-   | / impl<'a, T> DefinesSlot for Writer<'a, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `Writer<'a, T>`
-  --> $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/reader.rs
-   |
-   | / impl<T> DefinesSlot for Reader<'_, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `Reader<'_, T>`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/exclusive_reader.rs
-   |
-   | / impl<T> DefinesSlot for ExclusiveReader<'_, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `ExclusiveReader<'_, T>`
+   = help: the following other types implement trait `DefinesSlot`:
+             ExclusiveReader<'_, T>
+             veecle_os_runtime::mpsc::Reader<'_, T, N>
+             veecle_os_runtime::mpsc::Writer<'_, T, N>
+             veecle_os_runtime::single_writer::Reader<'_, T>
+             veecle_os_runtime::single_writer::Writer<'a, T>
 
 error[E0277]: invalid actor parameter type
   --> tests/ui/actor/unexpected_argument.rs:31:27
@@ -180,27 +105,12 @@ error[E0277]: invalid actor parameter type
    = help: the trait `DefinesSlot` is not implemented for `[u32; 0]`
    = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
    = note: parameters passed as initialization context need to be marked with `#[init_context]`
-help: the following other types implement trait `DefinesSlot`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/writer.rs
-   |
-   | / impl<'a, T> DefinesSlot for Writer<'a, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `Writer<'a, T>`
-  --> $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/reader.rs
-   |
-   | / impl<T> DefinesSlot for Reader<'_, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `Reader<'_, T>`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/exclusive_reader.rs
-   |
-   | / impl<T> DefinesSlot for ExclusiveReader<'_, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `ExclusiveReader<'_, T>`
+   = help: the following other types implement trait `DefinesSlot`:
+             ExclusiveReader<'_, T>
+             veecle_os_runtime::mpsc::Reader<'_, T, N>
+             veecle_os_runtime::mpsc::Writer<'_, T, N>
+             veecle_os_runtime::single_writer::Reader<'_, T>
+             veecle_os_runtime::single_writer::Writer<'a, T>
 
 error[E0277]: invalid actor parameter type
   --> tests/ui/actor/unexpected_argument.rs:31:27
@@ -211,27 +121,12 @@ error[E0277]: invalid actor parameter type
    = help: the trait `StoreRequest<'__dont_use_internal_actor_macro_lifetime>` is not implemented for `([u32; 0], ())`
    = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
    = note: parameters passed as initialization context need to be marked with `#[init_context]`
-help: the following other types implement trait `StoreRequest<'a>`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/writer.rs
-   |
-   | / impl<'a, T> StoreRequest<'a> for Writer<'a, T>
-   | | where
-   | |     T: Storable + 'static,
-   | |__________________________^ `Writer<'a, T>`
-  --> $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/reader.rs
-   |
-   | / impl<'a, T> StoreRequest<'a> for Reader<'a, T>
-   | | where
-   | |     T: Storable + 'static,
-   | |__________________________^ `Reader<'a, T>`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/exclusive_reader.rs
-   |
-   | / impl<'a, T> StoreRequest<'a> for ExclusiveReader<'a, T>
-   | | where
-   | |     T: Storable + 'static,
-   | |__________________________^ `ExclusiveReader<'a, T>`
+   = help: the following other types implement trait `StoreRequest<'a>`:
+             ExclusiveReader<'a, T>
+             veecle_os_runtime::mpsc::Reader<'a, T, N>
+             veecle_os_runtime::mpsc::Writer<'a, T, N>
+             veecle_os_runtime::single_writer::Reader<'a, T>
+             veecle_os_runtime::single_writer::Writer<'a, T>
 note: required by a bound in `veecle_os_runtime::Actor::StoreRequest`
   --> $WORKSPACE/veecle-os-runtime/src/actor.rs
    |
@@ -251,27 +146,12 @@ error[E0277]: invalid actor parameter type
    = help: the trait `DefinesSlot` is not implemented for `u32`
    = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
    = note: parameters passed as initialization context need to be marked with `#[init_context]`
-help: the following other types implement trait `DefinesSlot`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/writer.rs
-   |
-   | / impl<'a, T> DefinesSlot for Writer<'a, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `Writer<'a, T>`
-  --> $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/reader.rs
-   |
-   | / impl<T> DefinesSlot for Reader<'_, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `Reader<'_, T>`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/exclusive_reader.rs
-   |
-   | / impl<T> DefinesSlot for ExclusiveReader<'_, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `ExclusiveReader<'_, T>`
+   = help: the following other types implement trait `DefinesSlot`:
+             ExclusiveReader<'_, T>
+             veecle_os_runtime::mpsc::Reader<'_, T, N>
+             veecle_os_runtime::mpsc::Writer<'_, T, N>
+             veecle_os_runtime::single_writer::Reader<'_, T>
+             veecle_os_runtime::single_writer::Writer<'a, T>
 
 error[E0277]: invalid actor parameter type
   --> tests/ui/actor/unexpected_argument.rs:36:27
@@ -283,30 +163,15 @@ error[E0277]: invalid actor parameter type
 39 | | ) -> veecle_os_runtime::Never {
    | |_^ the function signature contains parameters that are neither init_context nor reader/writers
    |
-   = help: the trait `StoreRequest<'__dont_use_internal_actor_macro_lifetime>` is not implemented for `(Reader<'__dont_use_internal_actor_macro_lifetime, Sensor>, (u32, ()))`
+   = help: the trait `StoreRequest<'__dont_use_internal_actor_macro_lifetime>` is not implemented for `(veecle_os_runtime::single_writer::Reader<'__dont_use_internal_actor_macro_lifetime, Sensor>, (u32, ()))`
    = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
    = note: parameters passed as initialization context need to be marked with `#[init_context]`
-help: the following other types implement trait `StoreRequest<'a>`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/writer.rs
-   |
-   | / impl<'a, T> StoreRequest<'a> for Writer<'a, T>
-   | | where
-   | |     T: Storable + 'static,
-   | |__________________________^ `Writer<'a, T>`
-  --> $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/reader.rs
-   |
-   | / impl<'a, T> StoreRequest<'a> for Reader<'a, T>
-   | | where
-   | |     T: Storable + 'static,
-   | |__________________________^ `Reader<'a, T>`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/exclusive_reader.rs
-   |
-   | / impl<'a, T> StoreRequest<'a> for ExclusiveReader<'a, T>
-   | | where
-   | |     T: Storable + 'static,
-   | |__________________________^ `ExclusiveReader<'a, T>`
+   = help: the following other types implement trait `StoreRequest<'a>`:
+             ExclusiveReader<'a, T>
+             veecle_os_runtime::mpsc::Reader<'a, T, N>
+             veecle_os_runtime::mpsc::Writer<'a, T, N>
+             veecle_os_runtime::single_writer::Reader<'a, T>
+             veecle_os_runtime::single_writer::Writer<'a, T>
 note: required by a bound in `veecle_os_runtime::Actor::StoreRequest`
   --> $WORKSPACE/veecle-os-runtime/src/actor.rs
    |
@@ -327,27 +192,12 @@ error[E0277]: invalid actor parameter type
    = help: the trait `DefinesSlot` is not implemented for `usize`
    = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
    = note: parameters passed as initialization context need to be marked with `#[init_context]`
-help: the following other types implement trait `DefinesSlot`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/writer.rs
-   |
-   | / impl<'a, T> DefinesSlot for Writer<'a, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `Writer<'a, T>`
-  --> $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/reader.rs
-   |
-   | / impl<T> DefinesSlot for Reader<'_, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `Reader<'_, T>`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/exclusive_reader.rs
-   |
-   | / impl<T> DefinesSlot for ExclusiveReader<'_, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `ExclusiveReader<'_, T>`
+   = help: the following other types implement trait `DefinesSlot`:
+             ExclusiveReader<'_, T>
+             veecle_os_runtime::mpsc::Reader<'_, T, N>
+             veecle_os_runtime::mpsc::Writer<'_, T, N>
+             veecle_os_runtime::single_writer::Reader<'_, T>
+             veecle_os_runtime::single_writer::Writer<'a, T>
 
 error[E0277]: invalid actor parameter type
   --> tests/ui/actor/unexpected_argument.rs:44:27
@@ -363,27 +213,12 @@ error[E0277]: invalid actor parameter type
    = help: the trait `DefinesSlot` is not implemented for `u32`
    = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
    = note: parameters passed as initialization context need to be marked with `#[init_context]`
-help: the following other types implement trait `DefinesSlot`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/writer.rs
-   |
-   | / impl<'a, T> DefinesSlot for Writer<'a, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `Writer<'a, T>`
-  --> $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/reader.rs
-   |
-   | / impl<T> DefinesSlot for Reader<'_, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `Reader<'_, T>`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/exclusive_reader.rs
-   |
-   | / impl<T> DefinesSlot for ExclusiveReader<'_, T>
-   | | where
-   | |     T: Storable,
-   | |________________^ `ExclusiveReader<'_, T>`
+   = help: the following other types implement trait `DefinesSlot`:
+             ExclusiveReader<'_, T>
+             veecle_os_runtime::mpsc::Reader<'_, T, N>
+             veecle_os_runtime::mpsc::Writer<'_, T, N>
+             veecle_os_runtime::single_writer::Reader<'_, T>
+             veecle_os_runtime::single_writer::Writer<'a, T>
 
 error[E0277]: invalid actor parameter type
   --> tests/ui/actor/unexpected_argument.rs:44:27
@@ -396,30 +231,15 @@ error[E0277]: invalid actor parameter type
 48 | | ) -> veecle_os_runtime::Never {
    | |_^ the function signature contains parameters that are neither init_context nor reader/writers
    |
-   = help: the trait `StoreRequest<'__dont_use_internal_actor_macro_lifetime>` is not implemented for `(usize, (Reader<'__dont_use_internal_actor_macro_lifetime, Sensor>, (u32, ())))`
+   = help: the trait `StoreRequest<'__dont_use_internal_actor_macro_lifetime>` is not implemented for `(usize, (veecle_os_runtime::single_writer::Reader<'__dont_use_internal_actor_macro_lifetime, Sensor>, (u32, ())))`
    = note: only the init_context and readers/writers provided by the Veecle OS runtime may be used as actor parameters
    = note: parameters passed as initialization context need to be marked with `#[init_context]`
-help: the following other types implement trait `StoreRequest<'a>`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/writer.rs
-   |
-   | / impl<'a, T> StoreRequest<'a> for Writer<'a, T>
-   | | where
-   | |     T: Storable + 'static,
-   | |__________________________^ `Writer<'a, T>`
-  --> $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/reader.rs
-   |
-   | / impl<'a, T> StoreRequest<'a> for Reader<'a, T>
-   | | where
-   | |     T: Storable + 'static,
-   | |__________________________^ `Reader<'a, T>`
-   |
-  ::: $WORKSPACE/veecle-os-runtime/src/datastore/single_writer/exclusive_reader.rs
-   |
-   | / impl<'a, T> StoreRequest<'a> for ExclusiveReader<'a, T>
-   | | where
-   | |     T: Storable + 'static,
-   | |__________________________^ `ExclusiveReader<'a, T>`
+   = help: the following other types implement trait `StoreRequest<'a>`:
+             ExclusiveReader<'a, T>
+             veecle_os_runtime::mpsc::Reader<'a, T, N>
+             veecle_os_runtime::mpsc::Writer<'a, T, N>
+             veecle_os_runtime::single_writer::Reader<'a, T>
+             veecle_os_runtime::single_writer::Writer<'a, T>
 note: required by a bound in `veecle_os_runtime::Actor::StoreRequest`
   --> $WORKSPACE/veecle-os-runtime/src/actor.rs
    |

--- a/veecle-os-runtime/src/datastore/mpsc/mod.rs
+++ b/veecle-os-runtime/src/datastore/mpsc/mod.rs
@@ -1,0 +1,9 @@
+//! MPSC (multiple-producer, single-consumer) slot implementation.
+
+mod reader;
+mod slot;
+mod writer;
+
+pub use self::reader::Reader;
+pub(crate) use self::slot::Slot;
+pub use self::writer::Writer;

--- a/veecle-os-runtime/src/datastore/mpsc/reader.rs
+++ b/veecle-os-runtime/src/datastore/mpsc/reader.rs
@@ -1,0 +1,384 @@
+//! Exclusive reader for mpsc slots.
+
+use core::pin::Pin;
+
+use super::slot::Slot;
+use crate::Sealed;
+use crate::cons::{Cons, Nil};
+use crate::datastore::sync::generational;
+use crate::datastore::{Datastore, DatastoreExt, DefinesSlot, Storable, StoreRequest};
+
+/// Exclusive reader for [`Storable`] types from an mpsc slot.
+///
+/// Reads values written by multiple [`Writer`]s for the same type.
+/// Reading a value takes ownership from the slot, marking it as consumed.
+///
+/// The generic type `T` specifies the type of the value being read.
+/// The const generic `N` specifies the maximum number of writers.
+///
+/// # Usage
+///
+/// [`Reader::take_all_updated`] reads all available value via closure, waiting if no values are currently available.
+///
+/// [`Reader::take_all`] reads all available value via closure.
+///
+/// [`Reader::take_one`] returns one value if available.
+///
+/// # Examples
+///
+/// ```rust
+/// // Using `take_all` to process all available values.
+/// # use std::fmt::Debug;
+/// #
+/// # use veecle_os_runtime::{Storable, mpsc::Reader};
+/// #
+/// # #[derive(Debug, Default, Storable)]
+/// # pub struct Command(usize);
+/// #
+/// #[veecle_os_runtime::actor]
+/// async fn command_handler<const N: usize>(mut reader: Reader<'_, Command, N>) -> veecle_os_runtime::Never {
+///     loop {
+///         reader.wait_for_update().await;
+///         reader.take_all(|command| {
+///             // Process the command.
+///         });
+///     }
+/// }
+/// ```
+///
+/// [`Writer`]: super::Writer
+pub struct Reader<'a, T, const N: usize>
+where
+    T: Storable + 'static,
+{
+    slot: Pin<&'a Slot<T, N>>,
+    waiter: generational::Waiter<'a>,
+}
+
+impl<T, const N: usize> Reader<'_, T, N>
+where
+    T: Storable + 'static,
+{
+    /// Returns `true` if an unseen value is available.
+    ///
+    /// A value becomes "seen" after calling [`take_one`][Self::take_one], [`take_all`][Self::take_all],
+    /// or similar read methods.
+    ///
+    /// May return `true` after a reading method if more unseen values are available.
+    #[veecle_telemetry::instrument]
+    pub fn is_updated(&self) -> bool {
+        self.waiter.is_updated()
+    }
+
+    /// Waits for unseen values to become available.
+    ///
+    /// This future resolving does not imply that `previous_value != new_value`, just that a
+    /// [`Writer`][super::Writer] has written a value of `T` since the last read operation.
+    ///
+    /// Returns `&mut Self` to allow chaining method calls.
+    #[veecle_telemetry::instrument]
+    pub async fn wait_for_update(&mut self) -> &mut Self {
+        loop {
+            if self.is_updated() {
+                return self;
+            }
+
+            self.waiter.update_generation();
+            let _ = self.waiter.wait().await;
+        }
+    }
+
+    /// Takes the next available value, returns `None` if none are available.
+    #[veecle_telemetry::instrument]
+    pub fn take_one(&mut self) -> Option<T::DataType> {
+        for index in 0..self.slot.writer_count() {
+            if let Some(value) = self.slot.take(index) {
+                veecle_telemetry::trace!(
+                    "Slot taken",
+                    index = format_args!("{index:?}"),
+                    value = format_args!("{value:?}")
+                );
+                return Some(value);
+            }
+        }
+        // Update the generation if no unseen value is present.
+        self.waiter.update_generation();
+
+        None
+    }
+
+    /// Reads all available values.
+    ///
+    /// Takes ownership of each value and passes it to `f`.
+    #[veecle_telemetry::instrument]
+    pub fn take_all(&mut self, mut f: impl FnMut(T::DataType)) {
+        for index in 0..self.slot.writer_count() {
+            if let Some(value) = self.slot.take(index) {
+                veecle_telemetry::trace!(
+                    "Slot taken",
+                    index = format_args!("{index:?}"),
+                    value = format_args!("{value:?}")
+                );
+                f(value);
+            }
+        }
+
+        // Update the generation if no unseen value is present.
+        self.waiter.update_generation();
+    }
+
+    /// Reads all available values, waiting if none are available.
+    ///
+    /// Takes ownership of each value and passes it to `f`.
+    /// When no values are available, waits for new writes and returns after reading at least one value.
+    #[veecle_telemetry::instrument]
+    pub async fn take_all_updated(&mut self, mut f: impl FnMut(T::DataType)) {
+        loop {
+            let mut wait_for_update = true;
+            for index in 0..self.slot.writer_count() {
+                if let Some(value) = self.slot.take(index) {
+                    wait_for_update = false;
+                    veecle_telemetry::trace!(
+                        "Slot taken",
+                        index = format_args!("{index:?}"),
+                        value = format_args!("{value:?}")
+                    );
+                    f(value);
+                }
+            }
+
+            // Update the generation if no unseen value is present.
+            self.waiter.update_generation();
+
+            if wait_for_update {
+                let _ = self.waiter.wait().await;
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+impl<'a, T, const N: usize> Reader<'a, T, N>
+where
+    T: Storable + 'static,
+{
+    pub(crate) fn from_slot(slot: Pin<&'a Slot<T, N>>) -> Self {
+        Reader {
+            waiter: slot.waiter(),
+            slot,
+        }
+    }
+}
+
+impl<T, const N: usize> core::fmt::Debug for Reader<'_, T, N>
+where
+    T: Storable + 'static,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Reader").field("slot", &self.slot).finish()
+    }
+}
+
+impl<T, const N: usize> DefinesSlot for Reader<'_, T, N>
+where
+    T: Storable,
+{
+    type Slot = Cons<Slot<T, N>, Nil>;
+}
+
+impl<T, const N: usize> Sealed for Reader<'_, T, N> where T: Storable + 'static {}
+
+impl<'a, T, const N: usize> StoreRequest<'a> for Reader<'a, T, N>
+where
+    T: Storable + 'static,
+{
+    async fn request(datastore: Pin<&'a impl Datastore>, requestor: &'static str) -> Self {
+        datastore.mpsc_reader(requestor)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use core::pin::pin;
+    use futures::FutureExt;
+    use std::cell::Cell;
+
+    use crate::datastore::Storable;
+    use crate::datastore::mpsc::{Reader, Slot, Writer};
+    use crate::datastore::sync::generational;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct Data(usize);
+    impl Storable for Data {
+        type DataType = Self;
+    }
+
+    #[test]
+    fn is_updated_false_initially() {
+        let slot = pin!(Slot::<Data, 2>::new());
+        let reader = Reader::from_slot(slot.as_ref());
+        assert!(!reader.is_updated());
+    }
+
+    #[test]
+    fn is_updated_true_after_write() {
+        let source = pin!(generational::Source::new());
+        let slot = pin!(Slot::<Data, 2>::new());
+
+        let mut writer = Writer::new(source.as_ref().waiter(), slot.as_ref());
+        let reader = Reader::from_slot(slot.as_ref());
+
+        assert!(!reader.is_updated());
+
+        source.as_ref().increment_generation();
+        writer.write(Data(1)).now_or_never().unwrap();
+
+        assert!(reader.is_updated());
+    }
+
+    #[test]
+    fn wait_for_update_pends_then_resolves() {
+        let source = pin!(generational::Source::new());
+        let slot = pin!(Slot::<Data, 2>::new());
+
+        let mut writer = Writer::new(source.as_ref().waiter(), slot.as_ref());
+        let mut reader = Reader::from_slot(slot.as_ref());
+
+        assert!(reader.wait_for_update().now_or_never().is_none());
+
+        source.as_ref().increment_generation();
+        writer.write(Data(1)).now_or_never().unwrap();
+
+        reader.wait_for_update().now_or_never().unwrap();
+    }
+
+    #[test]
+    fn take_all_reads_all_values() {
+        let source = pin!(generational::Source::new());
+        let slot = pin!(Slot::<Data, 3>::new());
+
+        let mut writer0 = Writer::new(source.as_ref().waiter(), slot.as_ref());
+        let mut writer1 = Writer::new(source.as_ref().waiter(), slot.as_ref());
+        let mut reader = Reader::from_slot(slot.as_ref());
+
+        source.as_ref().increment_generation();
+        writer0.write(Data(10)).now_or_never().unwrap();
+
+        source.as_ref().increment_generation();
+        writer1.write(Data(20)).now_or_never().unwrap();
+
+        reader.wait_for_update().now_or_never().unwrap();
+
+        let mut values = std::vec::Vec::new();
+        reader.take_all(|v| values.push(v));
+        assert_eq!(values, std::vec![Data(10), Data(20)]);
+    }
+
+    #[test]
+    fn read_returns_none_when_exhausted() {
+        let slot = pin!(Slot::<Data, 2>::new());
+        let mut reader = Reader::from_slot(slot.as_ref());
+        assert!(reader.take_one().is_none());
+    }
+
+    #[test]
+    fn after_reading_all_values_is_updated_returns_false() {
+        let source = pin!(generational::Source::new());
+        let slot = pin!(Slot::<Data, 2>::new());
+
+        let mut writer = Writer::new(source.as_ref().waiter(), slot.as_ref());
+        let mut reader = Reader::from_slot(slot.as_ref());
+
+        source.as_ref().increment_generation();
+        writer.write(Data(1)).now_or_never().unwrap();
+
+        assert!(reader.is_updated());
+
+        reader.wait_for_update().now_or_never().unwrap();
+        reader.take_all(|_| {});
+
+        assert!(!reader.is_updated());
+    }
+
+    #[test]
+    fn take_all_updated_takes_values() {
+        let source = pin!(generational::Source::new());
+        let slot = pin!(Slot::<Data, 3>::new());
+
+        let mut writer0 = Writer::new(source.as_ref().waiter(), slot.as_ref());
+        let mut writer1 = Writer::new(source.as_ref().waiter(), slot.as_ref());
+        let mut reader = Reader::from_slot(slot.as_ref());
+
+        source.as_ref().increment_generation();
+        writer0.write(Data(10)).now_or_never().unwrap();
+
+        source.as_ref().increment_generation();
+        writer1.write(Data(20)).now_or_never().unwrap();
+
+        let values = std::rc::Rc::new(core::cell::RefCell::new(std::vec::Vec::new()));
+        let captured = values.clone();
+
+        let mut future = pin!(reader.take_all_updated(move |v| {
+            captured.borrow_mut().push(v);
+        }));
+        assert!(future.as_mut().now_or_never().is_some());
+        assert_eq!(*values.borrow(), std::vec![Data(10), Data(20)]);
+    }
+
+    #[test]
+    fn take_all_updated_waits_when_no_values_available() {
+        let source = pin!(generational::Source::new());
+        let slot = pin!(Slot::<Data, 2>::new());
+
+        let _writer = Writer::new(source.as_ref().waiter(), slot.as_ref());
+        let mut reader = Reader::from_slot(slot.as_ref());
+
+        let mut future = pin!(reader.take_all_updated(|_| {}));
+
+        assert!(future.as_mut().now_or_never().is_none());
+    }
+
+    #[test]
+    fn take_all_updated_reads_new_values_after_waiting() {
+        let source = pin!(generational::Source::new());
+        let slot = pin!(Slot::<Data, 2>::new());
+
+        let mut writer = Writer::new(source.as_ref().waiter(), slot.as_ref());
+        let mut reader = Reader::from_slot(slot.as_ref());
+
+        let future_hit = Cell::new(false);
+
+        let mut future = pin!(reader.take_all_updated(|_| {
+            future_hit.set(true);
+        }));
+
+        assert!(future.as_mut().now_or_never().is_none());
+
+        source.as_ref().increment_generation();
+        writer.write(Data(99)).now_or_never().unwrap();
+
+        assert!(future.as_mut().now_or_never().is_some());
+        assert!(future_hit.get());
+    }
+
+    #[test]
+    fn is_updated_true_after_reading_one_of_two_writes() {
+        let source = pin!(generational::Source::new());
+        let slot = pin!(Slot::<Data, 2>::new());
+
+        let mut writer0 = Writer::new(source.as_ref().waiter(), slot.as_ref());
+        let mut writer1 = Writer::new(source.as_ref().waiter(), slot.as_ref());
+        let mut reader = Reader::from_slot(slot.as_ref());
+
+        source.as_ref().increment_generation();
+        writer0.write(Data(10)).now_or_never().unwrap();
+        writer1.write(Data(20)).now_or_never().unwrap();
+
+        let value = reader.take_one();
+        assert_eq!(value, Some(Data(10)));
+
+        assert!(reader.is_updated());
+    }
+}

--- a/veecle-os-runtime/src/datastore/mpsc/slot.rs
+++ b/veecle-os-runtime/src/datastore/mpsc/slot.rs
@@ -1,0 +1,305 @@
+//! Slot implementation for mpsc slots.
+
+use crate::datastore::sync::generational;
+use crate::datastore::{SlotTrait, Storable};
+use core::any::TypeId;
+use core::cell::{Cell, RefCell};
+use core::pin::Pin;
+
+use pin_project::pin_project;
+use veecle_telemetry::SpanContext;
+
+/// Runtime storage for multiple storable values in an mpsc slot.
+///
+/// Each writer gets its own value indexed by position.
+#[pin_project]
+pub struct Slot<T, const N: usize>
+where
+    T: Storable + 'static,
+{
+    #[pin]
+    source: generational::Source,
+    writer_count: Cell<usize>,
+    items: [RefCell<Option<T::DataType>>; N],
+    writer_contexts: [Cell<Option<SpanContext>>; N],
+}
+
+impl<T, const N: usize> Slot<T, N>
+where
+    T: Storable + 'static,
+{
+    /// Creates a new mpsc `Slot`.
+    pub(crate) fn new() -> Self {
+        Self {
+            source: generational::Source::new(),
+            writer_count: Cell::new(0),
+            items: core::array::from_fn(|_| RefCell::new(None)),
+            writer_contexts: core::array::from_fn(|_| Cell::new(None)),
+        }
+    }
+
+    /// Assigns a writer index and returns it.
+    ///
+    /// # Panics
+    ///
+    /// If called more than `N` times.
+    pub(crate) fn take_writer(&self) -> usize {
+        let index = self.writer_count();
+        let type_name = core::any::type_name::<T>();
+        assert!(
+            index < N,
+            "too many writers for mpsc slot<{type_name}>: capacity is {N}",
+        );
+        self.writer_count.set(index + 1);
+        index
+    }
+
+    /// Returns the number of writers that have been assigned.
+    pub(crate) fn writer_count(&self) -> usize {
+        self.writer_count.get()
+    }
+
+    /// Writes a value to the slot at the given index.
+    ///
+    /// Stores the provided `span_context` to connect this write to the next read operation.
+    /// Returns `true` if a previous unseen value was overwritten.
+    #[veecle_telemetry::instrument]
+    pub(crate) fn write(
+        &self,
+        index: usize,
+        value: T::DataType,
+        span_context: Option<SpanContext>,
+    ) -> bool {
+        self.writer_contexts[index].set(span_context);
+        self.items[index].borrow_mut().replace(value).is_some()
+    }
+
+    /// Takes the value from a writer's slot, leaving behind `None`.
+    ///
+    /// Links the current span to the writer's span context.
+    #[veecle_telemetry::instrument]
+    pub(crate) fn take(&self, index: usize) -> Option<T::DataType> {
+        if let Some(writer_context) = self.writer_contexts[index].take() {
+            veecle_telemetry::CurrentSpan::add_link(writer_context);
+        }
+        self.items[index].borrow_mut().take()
+    }
+
+    /// Returns a new waiter for this slot's source.
+    pub(crate) fn waiter(self: Pin<&Self>) -> generational::Waiter<'_> {
+        self.project_ref().source.waiter()
+    }
+
+    /// Increments the slot generation and wakes the reader.
+    pub(crate) fn increment_generation(self: Pin<&Self>) {
+        self.project_ref().source.increment_generation();
+    }
+}
+
+impl<T, const N: usize> SlotTrait for Slot<T, N>
+where
+    T: Storable + 'static,
+{
+    fn new() -> Self {
+        Slot::new()
+    }
+
+    fn data_type_id() -> TypeId {
+        TypeId::of::<T>()
+    }
+
+    fn data_type_name() -> &'static str {
+        core::any::type_name::<T>()
+    }
+
+    fn validate_access_pattern(
+        (writers, writers_list): (usize, impl Iterator<Item = &'static str>),
+        (exclusive_readers, exclusive_readers_list): (usize, impl Iterator<Item = &'static str>),
+        (non_exclusive_readers, non_exclusive_readers_list): (
+            usize,
+            impl Iterator<Item = &'static str>,
+        ),
+    ) {
+        use crate::datastore::format_types;
+
+        let type_name = Self::data_type_name();
+
+        if writers < 1 {
+            panic!(
+                "missing writer for mpsc `{type_name}`, read by: {}",
+                format_types(exclusive_readers_list),
+            );
+        }
+        if writers > N {
+            panic!(
+                "too many writers ({writers}) for mpsc `{type_name}` with capacity {N}: {}",
+                format_types(writers_list),
+            );
+        }
+        if exclusive_readers != 1 {
+            panic!(
+                "mpsc `{type_name}` requires exactly 1 exclusive reader, found {exclusive_readers}: {}",
+                format_types(exclusive_readers_list),
+            );
+        }
+        if non_exclusive_readers != 0 {
+            panic!(
+                "mpsc `{type_name}` does not support non-exclusive readers: {}",
+                format_types(non_exclusive_readers_list),
+            );
+        }
+    }
+}
+
+impl<T, const N: usize> core::fmt::Debug for Slot<T, N>
+where
+    T: Storable + 'static,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Slot")
+            .field("source", &self.source)
+            .field("writer_count", &self.writer_count)
+            .field("items", &"<opaque>")
+            .finish()
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use core::pin::pin;
+
+    use crate::datastore::{SlotTrait, Storable};
+
+    use super::Slot;
+
+    #[derive(Debug)]
+    struct Data(usize);
+    impl Storable for Data {
+        type DataType = Self;
+    }
+
+    #[test]
+    fn new_initializes_correctly() {
+        let slot = pin!(Slot::<Data, 3>::new());
+        assert_eq!(slot.writer_count(), 0);
+        for index in 0..3 {
+            assert!(slot.take(index).is_none());
+        }
+    }
+
+    #[test]
+    fn take_writer_assigns_sequential_indices() {
+        let slot = pin!(Slot::<Data, 3>::new());
+        assert_eq!(slot.take_writer(), 0);
+        assert_eq!(slot.take_writer(), 1);
+        assert_eq!(slot.take_writer(), 2);
+        assert_eq!(slot.writer_count(), 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "too many writers for mpsc slot")]
+    fn take_writer_panics_at_capacity() {
+        let slot = pin!(Slot::<Data, 2>::new());
+        slot.take_writer();
+        slot.take_writer();
+        slot.take_writer();
+    }
+
+    #[test]
+    fn write_and_take() {
+        let slot = pin!(Slot::<Data, 2>::new());
+        assert!(!slot.write(0, Data(42), None));
+        assert_eq!(slot.take(0).unwrap().0, 42);
+        assert!(slot.take(1).is_none());
+    }
+
+    #[test]
+    fn write_returns_true_when_overwriting() {
+        let slot = pin!(Slot::<Data, 2>::new());
+        assert!(!slot.write(0, Data(10), None));
+        assert!(slot.write(0, Data(20), None));
+        assert_eq!(slot.take(0).unwrap().0, 20);
+    }
+
+    #[test]
+    fn take_removes_value() {
+        let slot = pin!(Slot::<Data, 2>::new());
+        slot.write(0, Data(10), None);
+        let taken = slot.take(0);
+        assert_eq!(taken.unwrap().0, 10);
+        assert!(slot.take(0).is_none());
+    }
+
+    #[test]
+    fn increment_generation_wakes_waiter() {
+        use futures::FutureExt;
+
+        let slot = pin!(Slot::<Data, 2>::new());
+        let waiter = slot.as_ref().waiter();
+        assert!(!waiter.is_updated());
+
+        slot.as_ref().increment_generation();
+        assert!(waiter.is_updated());
+        assert!(waiter.wait().now_or_never().is_some());
+    }
+
+    #[test]
+    fn validate_accepts_valid_pattern() {
+        Slot::<Data, 2>::validate_access_pattern(
+            (1, ["writer"].into_iter()),
+            (1, ["reader"].into_iter()),
+            (0, [].into_iter()),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "missing writer for mpsc")]
+    fn validate_rejects_no_writer() {
+        Slot::<Data, 2>::validate_access_pattern(
+            (0, [].into_iter()),
+            (1, ["reader"].into_iter()),
+            (0, [].into_iter()),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "too many writers")]
+    fn validate_rejects_too_many_writers() {
+        Slot::<Data, 2>::validate_access_pattern(
+            (3, ["w1", "w2", "w3"].into_iter()),
+            (1, ["reader"].into_iter()),
+            (0, [].into_iter()),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "requires exactly 1 exclusive reader, found 0")]
+    fn validate_rejects_no_reader() {
+        Slot::<Data, 2>::validate_access_pattern(
+            (1, ["writer"].into_iter()),
+            (0, [].into_iter()),
+            (0, [].into_iter()),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "requires exactly 1 exclusive reader, found 2")]
+    fn validate_rejects_multiple_readers() {
+        Slot::<Data, 2>::validate_access_pattern(
+            (1, ["writer"].into_iter()),
+            (2, ["r1", "r2"].into_iter()),
+            (0, [].into_iter()),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "does not support non-exclusive readers")]
+    fn validate_rejects_non_exclusive_reader() {
+        Slot::<Data, 2>::validate_access_pattern(
+            (1, ["writer"].into_iter()),
+            (1, ["reader"].into_iter()),
+            (1, ["non_exclusive"].into_iter()),
+        );
+    }
+}

--- a/veecle-os-runtime/src/datastore/mpsc/writer.rs
+++ b/veecle-os-runtime/src/datastore/mpsc/writer.rs
@@ -1,0 +1,209 @@
+//! Writer for mpsc slots.
+
+use core::fmt::Debug;
+use core::pin::Pin;
+
+use super::slot::Slot;
+use crate::Sealed;
+use crate::cons::Nil;
+use crate::datastore::sync::generational;
+use crate::datastore::{Datastore, DatastoreExt, DefinesSlot, Storable, StoreRequest};
+
+/// Writer for an mpsc [`Storable`] type.
+///
+/// Multiple writers can coexist for the same type, each writing to their own value.
+/// A single exclusive [`Reader`] consumes values from all writers.
+///
+/// The generic type `T` specifies the type of the value being written.
+/// The const generic `N` specifies the maximum number of writers.
+///
+/// # Usage
+///
+/// Each writer is assigned a unique place to store a value.
+/// [`Writer::write`] stores a value in that place and notifies the reader.
+/// Like [`single_writer::Writer`], [`Writer::write`] is async and waits to give the [`Reader`] a chance to read the value.
+///
+/// # Examples
+///
+/// ```rust
+/// // Writing values.
+/// # use std::fmt::Debug;
+/// #
+/// # use veecle_os_runtime::{Storable, mpsc::Writer};
+/// #
+/// # #[derive(Debug, Default, Storable)]
+/// # pub struct Command(usize);
+/// #
+/// #[veecle_os_runtime::actor]
+/// async fn command_sender<const N: usize>(mut writer: Writer<'_, Command, N>) -> veecle_os_runtime::Never {
+///     let mut counter = 0;
+///     loop {
+///         // After the first write, this call will yield to the executor before allowing the next write.
+///         writer.write(Command(counter)).await;
+///         counter += 1;
+///     }
+/// }
+/// ```
+///
+/// [`Reader`]: super::Reader
+/// [`single_writer::Writer`]: crate::single_writer::Writer
+#[derive(Debug)]
+pub struct Writer<'a, T, const N: usize>
+where
+    T: Storable + 'static,
+{
+    slot: Pin<&'a Slot<T, N>>,
+    waiter: generational::Waiter<'a>,
+    index: usize,
+}
+
+impl<T, const N: usize> Writer<'_, T, N>
+where
+    T: Storable + 'static,
+{
+    /// Writes a new value and notifies the reader.
+    #[veecle_telemetry::instrument]
+    pub async fn write(&mut self, item: T::DataType) {
+        use veecle_telemetry::future::FutureExt;
+        let span = veecle_telemetry::span!("write");
+        let span_context = span.context();
+        async move {
+            self.ready().await;
+
+            veecle_telemetry::trace!(
+                "Slot written",
+                index = format_args!("{:?}", self.index),
+                value = format_args!("{item:?}")
+            );
+            let had_unseen_value = self.slot.write(self.index, item, span_context);
+
+            if had_unseen_value {
+                let type_name = core::any::type_name::<T>();
+
+                veecle_telemetry::warn!(
+                    "Overwriting unseen value",
+                    type_name = type_name,
+                    writer_index = self.index as i64
+                );
+            }
+
+            self.waiter.update_generation();
+            self.slot.increment_generation();
+        }
+        .with_span(span)
+        .await;
+    }
+
+    /// Waits for the writer to be ready to perform a write operation.
+    ///
+    /// After awaiting this method, the next call to [`Writer::write()`]
+    /// is guaranteed to resolve immediately.
+    pub async fn ready(&mut self) {
+        let _ = self.waiter.wait().await;
+    }
+}
+
+impl<'a, T, const N: usize> Writer<'a, T, N>
+where
+    T: Storable + 'static,
+{
+    pub(crate) fn new(waiter: generational::Waiter<'a>, slot: Pin<&'a Slot<T, N>>) -> Self {
+        let index = slot.take_writer();
+        Self {
+            slot,
+            waiter,
+            index,
+        }
+    }
+}
+
+impl<T, const N: usize> DefinesSlot for Writer<'_, T, N>
+where
+    T: Storable,
+{
+    type Slot = Nil;
+}
+
+impl<T, const N: usize> Sealed for Writer<'_, T, N> where T: Storable + 'static {}
+
+impl<'a, T, const N: usize> StoreRequest<'a> for Writer<'a, T, N>
+where
+    T: Storable + 'static,
+{
+    async fn request(datastore: Pin<&'a impl Datastore>, requestor: &'static str) -> Self {
+        datastore.mpsc_writer(requestor)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use crate::datastore::Storable;
+    use crate::datastore::mpsc::{Slot, Writer};
+    use crate::datastore::sync::generational;
+    use core::pin::pin;
+
+    #[test]
+    fn ready_waits_for_increment() {
+        use futures::FutureExt;
+        #[derive(Debug)]
+        pub struct Data();
+        impl Storable for Data {
+            type DataType = Self;
+        }
+
+        let source = pin!(generational::Source::new());
+        let slot = pin!(Slot::<Data, 2>::new());
+        let mut writer = Writer::new(source.as_ref().waiter(), slot.as_ref());
+
+        assert!(writer.ready().now_or_never().is_none());
+        assert!(writer.write(Data {}).now_or_never().is_none());
+
+        source.as_ref().increment_generation();
+        assert!(writer.ready().now_or_never().is_some());
+        assert!(writer.write(Data {}).now_or_never().is_some());
+
+        assert!(writer.ready().now_or_never().is_none());
+        assert!(writer.write(Data {}).now_or_never().is_none());
+    }
+
+    #[test]
+    fn multiple_writers_get_unique_indices() {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub struct Data(usize);
+        impl Storable for Data {
+            type DataType = Self;
+        }
+
+        let source = pin!(generational::Source::new());
+        let slot = pin!(Slot::<Data, 3>::new());
+
+        let writer0 = Writer::new(source.as_ref().waiter(), slot.as_ref());
+        let writer1 = Writer::new(source.as_ref().waiter(), slot.as_ref());
+        let writer2 = Writer::new(source.as_ref().waiter(), slot.as_ref());
+
+        assert_eq!(writer0.index, 0);
+        assert_eq!(writer1.index, 1);
+        assert_eq!(writer2.index, 2);
+    }
+
+    #[test]
+    fn overwrite_existing_value() {
+        use futures::FutureExt;
+        #[derive(Debug)]
+        pub struct Data();
+        impl Storable for Data {
+            type DataType = Self;
+        }
+
+        let source = pin!(generational::Source::new());
+        let slot = pin!(Slot::<Data, 2>::new());
+        let mut writer = Writer::new(source.as_ref().waiter(), slot.as_ref());
+
+        source.as_ref().increment_generation();
+        assert!(writer.write(Data {}).now_or_never().is_some());
+
+        source.as_ref().increment_generation();
+        assert!(writer.write(Data {}).now_or_never().is_some());
+    }
+}

--- a/veecle-os-runtime/src/execute.rs
+++ b/veecle-os-runtime/src/execute.rs
@@ -9,6 +9,7 @@
 use crate::Never;
 use crate::actor::Actor;
 use crate::cons::{Cons, Nil, TupleConsToCons};
+use crate::datastore::mpsc;
 use crate::datastore::single_writer::{ExclusiveReader, Reader, Writer};
 use crate::datastore::sync::generational;
 use crate::datastore::{Datastore, SlotTrait, Storable, StoreRequest};
@@ -228,6 +229,28 @@ where
 }
 
 impl<T> AccessKind for ExclusiveReader<'_, T>
+where
+    T: Storable + 'static,
+{
+    fn reader(type_id: TypeId) -> bool {
+        type_id == TypeId::of::<T>()
+    }
+
+    fn exclusive_reader(type_id: TypeId) -> bool {
+        type_id == TypeId::of::<T>()
+    }
+}
+
+impl<T, const N: usize> AccessKind for mpsc::Writer<'_, T, N>
+where
+    T: Storable + 'static,
+{
+    fn writer(type_id: TypeId) -> bool {
+        type_id == TypeId::of::<T>()
+    }
+}
+
+impl<T, const N: usize> AccessKind for mpsc::Reader<'_, T, N>
 where
     T: Storable + 'static,
 {

--- a/veecle-os-runtime/src/lib.rs
+++ b/veecle-os-runtime/src/lib.rs
@@ -4,7 +4,7 @@
 //! Veecle OS applications are composed of [`Actor`]s that communicate with each other through
 //! slots.
 //! Slots come in different implementations; see [`single_writer`] for a slot implementation
-//! with one writer and multiple readers.
+//! with one writer and multiple readers, and [`mpsc`] for multiple writers with a single reader.
 //!
 //! This crate is meant to be used with asynchronous programming, which means that actors are expected to be async
 //! functions.
@@ -112,6 +112,7 @@ mod executor;
 pub mod memory_pool;
 
 pub use self::actor::{Actor, StoreRequest, actor};
+pub use self::datastore::mpsc;
 pub use self::datastore::single_writer;
 pub use self::datastore::{CombinableReader, CombineReaders, Modify, Storable};
 

--- a/veecle-os-runtime/tests/mpsc.rs
+++ b/veecle-os-runtime/tests/mpsc.rs
@@ -1,0 +1,120 @@
+#![expect(missing_docs)]
+
+use core::fmt::Debug;
+use core::sync::atomic::{AtomicUsize, Ordering};
+use std::future::poll_fn;
+use std::task::Poll;
+
+use veecle_os_runtime::mpsc::{Reader, Writer};
+use veecle_os_runtime::single_writer;
+use veecle_os_runtime::{Never, Storable};
+
+#[derive(Debug, PartialEq, Eq, Clone, Storable)]
+pub struct Event(pub u8);
+
+static READ_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+#[veecle_os_runtime::actor]
+async fn writer_a(mut writer: Writer<'_, Event, 3>) -> Never {
+    for index in 0..5 {
+        writer.write(Event(index)).await;
+    }
+    core::future::pending().await
+}
+
+#[veecle_os_runtime::actor]
+async fn writer_b(mut writer: Writer<'_, Event, 3>) -> Never {
+    for index in 10..15 {
+        writer.write(Event(index)).await;
+    }
+    core::future::pending().await
+}
+
+#[veecle_os_runtime::actor]
+async fn collector(mut reader: Reader<'_, Event, 3>) -> Never {
+    loop {
+        reader.wait_for_update().await;
+        let _ = reader.take_one();
+        READ_COUNTER.fetch_add(1, Ordering::AcqRel);
+    }
+}
+
+#[test]
+fn two_writers_one_reader() {
+    READ_COUNTER.store(0, Ordering::SeqCst);
+
+    veecle_os_test::block_on_future(veecle_os_test::execute! {
+        actors: [
+            WriterA,
+            WriterB,
+            Collector,
+        ],
+        validation: async || {
+            poll_fn(|context| {
+                if READ_COUNTER.load(Ordering::SeqCst) >= 10 {
+                    return Poll::Ready(());
+                }
+                context.waker().wake_by_ref();
+                Poll::Pending
+            }).await;
+        }
+    });
+    assert!(READ_COUNTER.load(Ordering::SeqCst) >= 10);
+}
+
+/// Tests that mpsc can coexist with single_writer in the same system.
+#[derive(Debug, PartialEq, Eq, Clone, Storable)]
+pub struct Trigger;
+
+static MIXED_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+#[veecle_os_runtime::actor]
+async fn trigger_writer(mut writer: single_writer::Writer<'_, Trigger>) -> Never {
+    for _ in 0..3 {
+        writer.write(Trigger).await;
+    }
+    core::future::pending().await
+}
+
+#[veecle_os_runtime::actor]
+async fn mpsc_writer_a(
+    mut writer: Writer<'_, Event, 2>,
+    mut trigger: single_writer::Reader<'_, Trigger>,
+) -> Never {
+    loop {
+        trigger.wait_for_update().await;
+        writer.write(Event(100)).await;
+    }
+}
+
+#[veecle_os_runtime::actor]
+async fn mixed_collector(mut reader: Reader<'_, Event, 2>) -> Never {
+    loop {
+        reader.wait_for_update().await;
+        let _ = reader.take_one();
+        MIXED_COUNTER.fetch_add(1, Ordering::AcqRel);
+    }
+}
+
+#[test]
+fn mixed_single_and_mpsc() {
+    MIXED_COUNTER.store(0, Ordering::SeqCst);
+
+    veecle_os_test::block_on_future(veecle_os_test::execute! {
+        actors: [
+            TriggerWriter,
+            MpscWriterA,
+            MixedCollector,
+        ],
+        validation: async || {
+            poll_fn(|context| {
+                if MIXED_COUNTER.load(Ordering::SeqCst) >= 3 {
+                    return Poll::Ready(());
+                }
+                context.waker().wake_by_ref();
+                Poll::Pending
+            }).await;
+        }
+    });
+    assert!(MIXED_COUNTER.load(Ordering::SeqCst) >= 3);
+}

--- a/veecle-os-runtime/tests/ui/mpsc/basic.rs
+++ b/veecle-os-runtime/tests/ui/mpsc/basic.rs
@@ -1,0 +1,24 @@
+#[derive(Debug, Default, veecle_os_runtime::Storable)]
+pub struct Command(pub u8);
+
+#[veecle_os_runtime::actor]
+async fn writer_actor<const N: usize>(
+    mut _writer: veecle_os_runtime::mpsc::Writer<'_, Command, N>,
+) -> veecle_os_runtime::Never {
+    unreachable!();
+}
+
+#[veecle_os_runtime::actor]
+async fn reader_actor<const N: usize>(
+    _reader: veecle_os_runtime::mpsc::Reader<'_, Command, N>,
+) -> veecle_os_runtime::Never {
+    unreachable!();
+}
+
+fn main() {
+    const N: usize = 2;
+
+    let _ = veecle_os_runtime::execute! {
+        actors: [WriterActor<N>, ReaderActor<N>],
+    };
+}

--- a/veecle-os-runtime/tests/ui/mpsc/multiple_writers.rs
+++ b/veecle-os-runtime/tests/ui/mpsc/multiple_writers.rs
@@ -1,0 +1,31 @@
+#[derive(Debug, Default, veecle_os_runtime::Storable)]
+pub struct Command(pub u8);
+
+#[veecle_os_runtime::actor]
+async fn writer_actor1<const N: usize>(
+    mut _writer: veecle_os_runtime::mpsc::Writer<'_, Command, N>,
+) -> veecle_os_runtime::Never {
+    unreachable!();
+}
+
+#[veecle_os_runtime::actor]
+async fn writer_actor2<const N: usize>(
+    mut _writer: veecle_os_runtime::mpsc::Writer<'_, Command, N>,
+) -> veecle_os_runtime::Never {
+    unreachable!();
+}
+
+#[veecle_os_runtime::actor]
+async fn reader_actor<const N: usize>(
+    _reader: veecle_os_runtime::mpsc::Reader<'_, Command, N>,
+) -> veecle_os_runtime::Never {
+    unreachable!();
+}
+
+fn main() {
+    const N: usize = 2;
+
+    let _ = veecle_os_runtime::execute! {
+        actors: [WriterActor1<N>, WriterActor2<N>, ReaderActor<N>],
+    };
+}


### PR DESCRIPTION
Adds `mpsc::Writer` and `mpsc::Reader` types that allow multiple actors to write to the same slot, each with their own value, consumed by a single exclusive reader.

Refs: DEV-437